### PR TITLE
Fix for devices without proxy

### DIFF
--- a/homematic/__init__.py
+++ b/homematic/__init__.py
@@ -30,7 +30,7 @@ def start():
     if Server:
         try:
             Server.start()
-            Server.connect()
+            # Server.connect()
             Server.proxyInit()
             return True
         except Exception as err:


### PR DESCRIPTION
Maybe it is only me but as mentioned in an issue the proxy for all devices was 'None'. I moved the connect into Server.start().