### PR TITLE
Add valve state as sensor to MAXThermostat and added MAXWallThermostat

### DIFF
--- a/pyhomematic/devicetypes/thermostats.py
+++ b/pyhomematic/devicetypes/thermostats.py
@@ -169,7 +169,22 @@ class MAXThermostat(HMThermostat, HelperLowBat, HelperValveState):
                                 "MANU_MODE": [1],
                                 "BOOST_MODE": [1]})
         self.ATTRIBUTENODE.update({"LOWBAT": [0], "CONTROL_MODE": [1]})
+        
+class MAXWallThermostat(HMThermostat, HelperLowBat):
+    """
+    BC-TC-C-WM-4
+    ClimateControl-RadiatorThermostat that measures temperature and allows to set a target temperature or use some automatic mode.
+    """
+    def __init__(self, device_description, proxy, resolveparamsets=False):
+        super().__init__(device_description, proxy, resolveparamsets)
 
+        # init metadata
+        self.SENSORNODE.update({"ACTUAL_TEMPERATURE": [1]})
+        self.WRITENODE.update({"SET_TEMPERATURE": [1]})
+        self.ACTIONNODE.update({"AUTO_MODE": [1],
+                                "MANU_MODE": [1],
+                                "BOOST_MODE": [1]})
+        self.ATTRIBUTENODE.update({"LOWBAT": [0], "CONTROL_MODE": [1]})
 
 DEVICETYPES = {
     "HM-CC-RT-DN": Thermostat,
@@ -181,5 +196,5 @@ DEVICETYPES = {
     "BC-RT-TRX-CyG-2": MAXThermostat,
     "BC-RT-TRX-CyG-3": MAXThermostat,
     "BC-RT-TRX-CyG-4": MAXThermostat,
-    "BC-TC-C-WM-4": MAXThermostat
+    "BC-TC-C-WM-4": MAXWallThermostat
 }

--- a/pyhomematic/devicetypes/thermostats.py
+++ b/pyhomematic/devicetypes/thermostats.py
@@ -105,7 +105,7 @@ class HMThermostat(HMDevice):
 class Thermostat(HMThermostat, HelperBatteryState, HelperValveState):
     """
     HM-CC-RT-DN, HM-CC-RT-DN-BoM
-    ClimateControl-RadiatorThermostat that measures temperature and allows to set a target temperature or use some automatic mode.
+    ClimateControl-Radiator Thermostat that measures temperature and allows to set a target temperature or use some automatic mode.
     """
     def __init__(self, device_description, proxy, resolveparamsets=False):
         super().__init__(device_description, proxy, resolveparamsets)
@@ -124,7 +124,7 @@ class Thermostat(HMThermostat, HelperBatteryState, HelperValveState):
 class ThermostatWall(HMThermostat, AreaThermostat, HelperBatteryState):
     """
     HM-TC-IT-WM-W-EU
-    ClimateControl-RadiatorThermostat that measures temperature and allows to set a target temperature or use some automatic mode.
+    ClimateControl-Wall Thermostat that measures temperature and allows to set a target temperature or use some automatic mode.
     """
     def __init__(self, device_description, proxy, resolveparamsets=False):
         super().__init__(device_description, proxy, resolveparamsets)
@@ -142,7 +142,7 @@ class ThermostatWall(HMThermostat, AreaThermostat, HelperBatteryState):
 class ThermostatWall2(HMThermostat, AreaThermostat, HelperBatteryState):
     """
     HM-CC-TC
-    ClimateControl-RadiatorThermostat that measures temperature and allows to set a target temperature or use some automatic mode.
+    ClimateControl-Wall Thermostat that measures temperature and allows to set a target temperature or use some automatic mode.
     """
     def __init__(self, device_description, proxy, resolveparamsets=False):
         super().__init__(device_description, proxy, resolveparamsets)
@@ -156,24 +156,25 @@ class ThermostatWall2(HMThermostat, AreaThermostat, HelperBatteryState):
 class MAXThermostat(HMThermostat, HelperLowBat, HelperValveState):
     """
     BC-RT-TRX-CyG, BC-RT-TRX-CyG-2, BC-RT-TRX-CyG-3, BC-RT-TRX-CyG-4
-    ClimateControl-RadiatorThermostat that measures temperature and allows to set a target temperature or use some automatic mode.
+    ClimateControl-Radiator Thermostat that measures temperature and allows to set a target temperature or use some automatic mode.
     """
     def __init__(self, device_description, proxy, resolveparamsets=False):
         super().__init__(device_description, proxy, resolveparamsets)
 
         # init metadata
-        self.SENSORNODE.update({"ACTUAL_TEMPERATURE": [1],
-                                "VALVE_STATE": [1]})
+        self.SENSORNODE.update({"ACTUAL_TEMPERATURE": [1]})
         self.WRITENODE.update({"SET_TEMPERATURE": [1]})
         self.ACTIONNODE.update({"AUTO_MODE": [1],
                                 "MANU_MODE": [1],
                                 "BOOST_MODE": [1]})
-        self.ATTRIBUTENODE.update({"LOWBAT": [0], "CONTROL_MODE": [1]})
+        self.ATTRIBUTENODE.update({"LOWBAT": [0],
+                                   "CONTROL_MODE": [1],
+                                   "VALVE_STATE": [1]})
         
 class MAXWallThermostat(HMThermostat, HelperLowBat):
     """
     BC-TC-C-WM-4
-    ClimateControl-RadiatorThermostat that measures temperature and allows to set a target temperature or use some automatic mode.
+    ClimateControl-Wall Thermostat that measures temperature and allows to set a target temperature or use some automatic mode.
     """
     def __init__(self, device_description, proxy, resolveparamsets=False):
         super().__init__(device_description, proxy, resolveparamsets)

--- a/pyhomematic/devicetypes/thermostats.py
+++ b/pyhomematic/devicetypes/thermostats.py
@@ -153,7 +153,7 @@ class ThermostatWall2(HMThermostat, AreaThermostat, HelperBatteryState):
         self.WRITENODE.update({"SETPOINT": [2]})
 
 
-class MAXThermostat(HMThermostat, HelperLowBat):
+class MAXThermostat(HMThermostat, HelperLowBat, HelperValveState):
     """
     BC-RT-TRX-CyG, BC-RT-TRX-CyG-2, BC-RT-TRX-CyG-3, BC-RT-TRX-CyG-4
     ClimateControl-RadiatorThermostat that measures temperature and allows to set a target temperature or use some automatic mode.
@@ -162,7 +162,8 @@ class MAXThermostat(HMThermostat, HelperLowBat):
         super().__init__(device_description, proxy, resolveparamsets)
 
         # init metadata
-        self.SENSORNODE.update({"ACTUAL_TEMPERATURE": [1]})
+        self.SENSORNODE.update({"ACTUAL_TEMPERATURE": [1],
+                                "VALVE_STATE": [1]})
         self.WRITENODE.update({"SET_TEMPERATURE": [1]})
         self.ACTIONNODE.update({"AUTO_MODE": [1],
                                 "MANU_MODE": [1],


### PR DESCRIPTION
Extend the ability of MAXThermostat to now report valve state as a sensor output. This then means that we need a separate device for wall thermostat controllers as they do not have valve state, so added MAXWallThermostat

Tested using home assistant and a Max!Cube flashed with CULFW (via homegear)