### PR TITLE
Add class for MAX shutter contacts

### DIFF
--- a/pyhomematic/devicetypes/sensors.py
+++ b/pyhomematic/devicetypes/sensors.py
@@ -38,6 +38,15 @@ class ShutterContact(IPShutterContact, HelperSabotage):
     pass
 
 
+class MaxShutterContact(HMBinarySensor, HelperBinaryState, HelperLowBat):
+    """Door / Window contact that emits its open/closed state."""
+    def __init__(self, device_description, proxy, resolveparamsets=False):
+        super().__init__(device_description, proxy, resolveparamsets)
+
+        # init metadata
+        self.ATTRIBUTENODE.update({"LOWBAT": [0]})
+
+
 class TiltSensor(HMBinarySensor, HelperBinaryState, HelperLowBat):
     """Sensor that emits its tilted state."""
     def is_tilted(self, channel=None):
@@ -345,7 +354,7 @@ DEVICETYPES = {
     "HM-Sec-SC-2": ShutterContact,
     "HM-Sec-SCo": ShutterContact,
     "ZEL STG RM FFK": ShutterContact,
-    "BC-SC-Rd-WM-2": ShutterContact,
+    "BC-SC-Rd-WM-2": MaxShutterContact,
     "HM-SCI-3-FM": IPShutterContact,
     "HMIP-SWDO": IPShutterContact,
     "HM-Sec-RHS": RotaryHandleSensor,


### PR DESCRIPTION
MAX devices report 'LOWBAT' on channel 0 and have no sabotage detection.

Requires changes in homeassistant's pyhomematic components. Is it enough to create a PR there and reference this PR?