### PR TITLE
Add basic support for HMIP-eTRV (Homematic IP Thermostat)

### DIFF
--- a/pyhomematic/devicetypes/helper.py
+++ b/pyhomematic/devicetypes/helper.py
@@ -28,6 +28,18 @@ class HelperLowBat(HMDevice):
         """ Returns if the battery is low. """
         return self.getAttributeData("LOWBAT", channel)
 
+class HelperLowBatIP(HMDevice):
+    """This Helper adds easy access to read the LOWBAT state"""
+    def __init__(self, device_description, proxy, resolveparamsets=False):
+        super().__init__(device_description, proxy, resolveparamsets)
+
+        # init metadata
+        self.ATTRIBUTENODE.update({"LOW_BAT": self.ELEMENT})
+
+    def low_batt(self, channel=None):
+        """ Returns if the battery is low. """
+        return self.getAttributeData("LOW_BAT", channel)
+
 
 class HelperWorking(HMDevice):
     """This helper provides access to the WORKING state of some devices."""

--- a/pyhomematic/devicetypes/thermostats.py
+++ b/pyhomematic/devicetypes/thermostats.py
@@ -187,6 +187,40 @@ class MAXWallThermostat(HMThermostat, HelperLowBat):
                                 "BOOST_MODE": [1]})
         self.ATTRIBUTENODE.update({"LOWBAT": [0], "CONTROL_MODE": [1]})
 
+class IPThermostat(HMThermostat, HelperValveState):
+    """
+    HPIM-eTRV
+    ClimateControl-Radiator Thermostat that measures temperature and allows to set a target temperature or use some automatic mode.
+    """
+    def __init__(self, device_description, proxy, resolveparamsets=False):
+        super().__init__(device_description, proxy, resolveparamsets)
+
+        # init metadata
+        self.SENSORNODE.update({"ACTUAL_TEMPERATURE": [1]})
+        self.WRITENODE.update({"SET_POINT_TEMPERATURE": [1]})
+        self.ACTIONNODE.update({"BOOST_MODE": [1]})
+        self.ATTRIBUTENODE.update({"LOW_BAT": [0],
+                                   "CONTROL_MODE": [1],
+                                   "VALVE_STATE": [1]})
+
+    def get_set_temperature(self):
+        """ Returns the current target temperature. """
+        return self.getWriteData("SET_POINT_TEMPERATURE")
+
+    def set_temperature(self, target_temperature):
+        """ Set the target temperature. """
+        try:
+            target_temperature = float(target_temperature)
+        except Exception as err:
+            LOG.debug("Thermostat.set_temperature: Exception %s" % (err,))
+            return False
+        self.writeNodeData("SET_POINT_TEMPERATURE", target_temperature)
+
+    def turnoff(self):
+        """ Turn off Thermostat. """
+        self.writeNodeData("SET_POINT_TEMPERATURE", self.OFF_VALUE)
+
+
 DEVICETYPES = {
     "HM-CC-RT-DN": Thermostat,
     "HM-CC-RT-DN-BoM": Thermostat,
@@ -197,5 +231,6 @@ DEVICETYPES = {
     "BC-RT-TRX-CyG-2": MAXThermostat,
     "BC-RT-TRX-CyG-3": MAXThermostat,
     "BC-RT-TRX-CyG-4": MAXThermostat,
-    "BC-TC-C-WM-4": MAXWallThermostat
+    "BC-TC-C-WM-4": MAXWallThermostat,
+    "HMIP-eTRV": IPThermostat
 }

--- a/pyhomematic/devicetypes/thermostats.py
+++ b/pyhomematic/devicetypes/thermostats.py
@@ -1,7 +1,7 @@
 import logging
 from pyhomematic.devicetypes.generic import HMDevice
 from pyhomematic.devicetypes.sensors import AreaThermostat
-from pyhomematic.devicetypes.helper import HelperValveState, HelperBatteryState, HelperLowBat
+from pyhomematic.devicetypes.helper import HelperValveState, HelperBatteryState, HelperLowBat, HelperLowBatIP
 
 LOG = logging.getLogger(__name__)
 
@@ -187,7 +187,7 @@ class MAXWallThermostat(HMThermostat, HelperLowBat):
                                 "BOOST_MODE": [1]})
         self.ATTRIBUTENODE.update({"LOWBAT": [0], "CONTROL_MODE": [1]})
 
-class IPThermostat(HMThermostat, HelperValveState):
+class IPThermostat(HMThermostat, HelperLowBatIP, HelperValveState):
     """
     HPIM-eTRV
     ClimateControl-Radiator Thermostat that measures temperature and allows to set a target temperature or use some automatic mode.


### PR DESCRIPTION
This is super basic support for the new Homematic IP thermostat HMIP-eTRV. It enables pyhomematic to read the current temperature and read/write the set point temperature.

For usage with Home Assistant, additional changes in the components' source of home assistant have to be done:

components/homematic.py:65 - Add IPThermostat to list of supported devices

```
DISCOVER_CLIMATE: [
        'Thermostat', 'ThermostatWall', 'MAXThermostat', 'ThermostatWall2',
        'MAXWallThermostat', 'IPThermostat'],
``` 

/components/climate/homematic.py:90 - HMIP uses another key for the set point temp, so we need to handle it without breaking compatibility:

```
@property
    def target_temperature(self):
        """Return the target temperature."""
        if not self.available:
            return None
        if self._data.get('SET_POINT_TEMPERATURE'):
            return self._data.get('SET_POINT_TEMPERATURE', None)
        else:
            return self._data.get('SET_TEMPERATURE', None)
```

/components/climate/homematic.py:125 - Add the new key to the data dict

```
def _init_data_struct(self):
        """Generate a data dict (self._data) from the Homematic metadata."""
        # Add state to data dict
        self._data.update({"CONTROL_MODE": STATE_UNKNOWN,
                           "SET_TEMPERATURE": STATE_UNKNOWN,
                           "SET_POINT_TEMPERATURE": STATE_UNKNOWN,
                           "ACTUAL_TEMPERATURE": STATE_UNKNOWN})
``` 