### PR TITLE
Fixing HM-CC-TC

### DIFF
--- a/pyhomematic/devicetypes/thermostats.py
+++ b/pyhomematic/devicetypes/thermostats.py
@@ -235,23 +235,6 @@ class IPThermostat(HMThermostat, HelperLowBatIP, HelperValveState):
                                    "CONTROL_MODE": [1],
                                    "VALVE_STATE": [1]})
 
-    def get_set_temperature(self):
-        """ Returns the current target temperature. """
-        return self.getWriteData("SET_POINT_TEMPERATURE")
-
-    def set_temperature(self, target_temperature):
-        """ Set the target temperature. """
-        try:
-            target_temperature = float(target_temperature)
-        except Exception as err:
-            LOG.debug("Thermostat.set_temperature: Exception %s" % (err,))
-            return False
-        self.writeNodeData("SET_POINT_TEMPERATURE", target_temperature)
-
-    def turnoff(self):
-        """ Turn off Thermostat. """
-        self.writeNodeData("SET_POINT_TEMPERATURE", self.OFF_VALUE)
-
 
 DEVICETYPES = {
     "HM-CC-RT-DN": Thermostat,

--- a/pyhomematic/devicetypes/thermostats.py
+++ b/pyhomematic/devicetypes/thermostats.py
@@ -32,11 +32,16 @@ class HMThermostat(HMDevice):
             "HM-CC-TC": {
                 "set_temp": "SETPOINT",
                 "get_temp": "TEMPERATURE",
-                "ctrl_mode": "CONTROL_MODE"
+                "ctrl_mode": "MODE_TEMPERATUR_REGULATOR"
             },
             "ZEL STG RM FWT": {
                 "set_temp": "SETPOINT",
                 "get_temp": "TEMPERATURE",
+                "ctrl_mode": "MODE_TEMPERATUR_REGULATOR"
+            },
+            "HMIP-eTRV": {
+                "set_temp": "SET_POINT_TEMPERATURE",
+                "get_temp": "ACTUAL_TEMPERATURE",
                 "ctrl_mode": "CONTROL_MODE"
             }
         }

--- a/pyhomematic/devicetypes/thermostats.py
+++ b/pyhomematic/devicetypes/thermostats.py
@@ -46,12 +46,10 @@ class HMThermostat(HMDevice):
 
     def actual_temperature(self):
         """ Returns the current temperature. """
-        #return self.getSensorData("ACTUAL_TEMPERATURE")
         return self.getSensorData(self._get_temp)
 
     def get_set_temperature(self):
         """ Returns the current target temperature. """
-        #return self.getWriteData("SET_TEMPERATURE")
         return self.getWriteData(self._set_temp)
 
     def set_temperature(self, target_temperature):
@@ -61,18 +59,15 @@ class HMThermostat(HMDevice):
         except Exception as err:
             LOG.debug("Thermostat.set_temperature: Exception %s" % (err,))
             return False
-        #self.writeNodeData("SET_TEMPERATURE", target_temperature)
         self.writeNodeData(self._set_temp, target_temperature)
 
     def turnoff(self):
         """ Turn off Thermostat. """
-        #self.writeNodeData("SET_TEMPERATURE", self.OFF_VALUE)
         self.writeNodeData(self._set_temp, self.OFF_VALUE)
 
     @property
     def MODE(self):
         """ Return mode. """
-        #return self.getAttributeData("CONTROL_MODE")
         return self.getAttributeData(self._ctrl_mode)
 
     @MODE.setter

--- a/pyhomematic/devicetypes/thermostats.py
+++ b/pyhomematic/devicetypes/thermostats.py
@@ -23,13 +23,36 @@ class HMThermostat(HMDevice):
 
         self.mode = None
 
+        self._NODEVARIATIONS = {
+            "default": {
+                "set_temp": "SET_TEMPERATURE",
+                "get_temp": "ACTUAL_TEMPERATURE",
+                "ctrl_mode": "CONTROL_MODE"
+            },
+            "HM-CC-TC": {
+                "set_temp": "SETPOINT",
+                "get_temp": "TEMPERATURE",
+                "ctrl_mode": "CONTROL_MODE"
+            },
+            "ZEL STG RM FWT": {
+                "set_temp": "SETPOINT",
+                "get_temp": "TEMPERATURE",
+                "ctrl_mode": "CONTROL_MODE"
+            }
+        }
+        self._get_temp = self._NODEVARIATIONS.get(self._TYPE, self._NODEVARIATIONS['default']).get('get_temp')
+        self._set_temp = self._NODEVARIATIONS.get(self._TYPE, self._NODEVARIATIONS['default']).get('set_temp')
+        self._ctrl_mode = self._NODEVARIATIONS.get(self._TYPE, self._NODEVARIATIONS['default']).get('ctrl_mode')
+
     def actual_temperature(self):
         """ Returns the current temperature. """
-        return self.getSensorData("ACTUAL_TEMPERATURE")
+        #return self.getSensorData("ACTUAL_TEMPERATURE")
+        return self.getSensorData(self._get_temp)
 
     def get_set_temperature(self):
         """ Returns the current target temperature. """
-        return self.getWriteData("SET_TEMPERATURE")
+        #return self.getWriteData("SET_TEMPERATURE")
+        return self.getWriteData(self._set_temp)
 
     def set_temperature(self, target_temperature):
         """ Set the target temperature. """
@@ -38,16 +61,19 @@ class HMThermostat(HMDevice):
         except Exception as err:
             LOG.debug("Thermostat.set_temperature: Exception %s" % (err,))
             return False
-        self.writeNodeData("SET_TEMPERATURE", target_temperature)
+        #self.writeNodeData("SET_TEMPERATURE", target_temperature)
+        self.writeNodeData(self._set_temp, target_temperature)
 
     def turnoff(self):
         """ Turn off Thermostat. """
-        self.writeNodeData("SET_TEMPERATURE", self.OFF_VALUE)
+        #self.writeNodeData("SET_TEMPERATURE", self.OFF_VALUE)
+        self.writeNodeData(self._set_temp, self.OFF_VALUE)
 
     @property
     def MODE(self):
         """ Return mode. """
-        return self.getAttributeData("CONTROL_MODE")
+        #return self.getAttributeData("CONTROL_MODE")
+        return self.getAttributeData(self._ctrl_mode)
 
     @MODE.setter
     def MODE(self, setmode):
@@ -151,6 +177,12 @@ class ThermostatWall2(HMThermostat, AreaThermostat, HelperBatteryState):
         self.SENSORNODE.update({"TEMPERATURE": [1],
                                 "HUMIDITY": [1]})
         self.WRITENODE.update({"SETPOINT": [2]})
+        # Remove invalid parameters
+        self.ATTRIBUTENODE.pop("BATTERY_STATE", None)
+        self.ATTRIBUTENODE.pop("CONTROL_MODE", None)
+        self.SENSORNODE.pop("ACTUAL_TEMPERATURE", None)
+        self.SENSORNODE.pop("ACTUAL_HUMIDITY", None)
+        self.WRITENODE.pop("SET_TEMPERATURE", None)
 
 
 class MAXThermostat(HMThermostat, HelperLowBat, HelperValveState):

--- a/pyhomematic/devicetypes/thermostats.py
+++ b/pyhomematic/devicetypes/thermostats.py
@@ -25,37 +25,37 @@ class HMThermostat(HMDevice):
 
         self._NODEVARIATIONS = {
             "default": {
-                "set_temp": "SET_TEMPERATURE",
-                "get_temp": "ACTUAL_TEMPERATURE",
-                "ctrl_mode": "CONTROL_MODE"
+                "datapoint_set_temperature": "SET_TEMPERATURE",
+                "datapoint_temperature": "ACTUAL_TEMPERATURE",
+                "datapoint_control_mode": "CONTROL_MODE"
             },
             "HM-CC-TC": {
-                "set_temp": "SETPOINT",
-                "get_temp": "TEMPERATURE",
-                "ctrl_mode": "MODE_TEMPERATUR_REGULATOR"
+                "datapoint_set_temperature": "SETPOINT",
+                "datapoint_temperature": "TEMPERATURE",
+                "datapoint_control_mode": "MODE_TEMPERATUR_REGULATOR"
             },
             "ZEL STG RM FWT": {
-                "set_temp": "SETPOINT",
-                "get_temp": "TEMPERATURE",
-                "ctrl_mode": "MODE_TEMPERATUR_REGULATOR"
+                "datapoint_set_temperature": "SETPOINT",
+                "datapoint_temperature": "TEMPERATURE",
+                "datapoint_control_mode": "MODE_TEMPERATUR_REGULATOR"
             },
             "HMIP-eTRV": {
-                "set_temp": "SET_POINT_TEMPERATURE",
-                "get_temp": "ACTUAL_TEMPERATURE",
-                "ctrl_mode": "CONTROL_MODE"
+                "datapoint_set_temperature": "SET_POINT_TEMPERATURE",
+                "datapoint_temperature": "ACTUAL_TEMPERATURE",
+                "datapoint_control_mode": "CONTROL_MODE"
             }
         }
-        self._get_temp = self._NODEVARIATIONS.get(self._TYPE, self._NODEVARIATIONS['default']).get('get_temp')
-        self._set_temp = self._NODEVARIATIONS.get(self._TYPE, self._NODEVARIATIONS['default']).get('set_temp')
-        self._ctrl_mode = self._NODEVARIATIONS.get(self._TYPE, self._NODEVARIATIONS['default']).get('ctrl_mode')
+        self.datapoint_temperature = self._NODEVARIATIONS.get(self._TYPE, self._NODEVARIATIONS['default']).get('datapoint_temperature')
+        self.datapoint_set_temperature = self._NODEVARIATIONS.get(self._TYPE, self._NODEVARIATIONS['default']).get('datapoint_set_temperature')
+        self.datapoint_control_mode = self._NODEVARIATIONS.get(self._TYPE, self._NODEVARIATIONS['default']).get('datapoint_control_mode')
 
     def actual_temperature(self):
         """ Returns the current temperature. """
-        return self.getSensorData(self._get_temp)
+        return self.getSensorData(self.datapoint_temperature)
 
     def get_set_temperature(self):
         """ Returns the current target temperature. """
-        return self.getWriteData(self._set_temp)
+        return self.getWriteData(self.datapoint_set_temperature)
 
     def set_temperature(self, target_temperature):
         """ Set the target temperature. """
@@ -64,16 +64,16 @@ class HMThermostat(HMDevice):
         except Exception as err:
             LOG.debug("Thermostat.set_temperature: Exception %s" % (err,))
             return False
-        self.writeNodeData(self._set_temp, target_temperature)
+        self.writeNodeData(self.datapoint_set_temperature, target_temperature)
 
     def turnoff(self):
         """ Turn off Thermostat. """
-        self.writeNodeData(self._set_temp, self.OFF_VALUE)
+        self.writeNodeData(self.datapoint_set_temperature, self.OFF_VALUE)
 
     @property
     def MODE(self):
         """ Return mode. """
-        return self.getAttributeData(self._ctrl_mode)
+        return self.getAttributeData(self.datapoint_control_mode)
 
     @MODE.setter
     def MODE(self, setmode):

--- a/thermostattest.py
+++ b/thermostattest.py
@@ -1,0 +1,9 @@
+#!/usr/bin/python3
+
+import time
+import sys
+import logging
+from pyhomematic import HMConnection
+logging.basicConfig(level=logging.INFO)
+p = HMConnection(interface_id="myserver", autostart=True, remotes={"rf":{"ip":"192.168.1.23","port": 2001}})
+#MEQ1585773

--- a/thermostattest.py
+++ b/thermostattest.py
@@ -1,9 +1,0 @@
-#!/usr/bin/python3
-
-import time
-import sys
-import logging
-from pyhomematic import HMConnection
-logging.basicConfig(level=logging.INFO)
-p = HMConnection(interface_id="myserver", autostart=True, remotes={"rf":{"ip":"192.168.1.23","port": 2001}})
-#MEQ1585773


### PR DESCRIPTION
Mit dieser Lösung passiert die ganze Logik nur noch in pyhomematic, und HASS müsste quasi nur noch die Methoden `get_temperature` usw. aufrufen. Ich kann bestätigen, dass meine normalen Thermostate und der HM-CC-TC zumindest innerhalb von pyhomematic funktionieren. In HASS sind die Parameter (`ACTUAL_TEMPERATURE` usw.) im Moment hardcoded.