### PR TITLE
Adding support for HmIP-FSM and HmIP-BSM

### DIFF
--- a/pyhomematic/devicetypes/actors.py
+++ b/pyhomematic/devicetypes/actors.py
@@ -274,6 +274,8 @@ class IPSwitch(GenericSwitch, HelperActionOnTime):
     def ELEMENT(self):
         if "HmIP-BSM" in self.TYPE:
             return [4]
+        elif "HmIP-FSM" in self.TYPE:
+            return [2]
         else:
             return [3]
 

--- a/pyhomematic/devicetypes/actors.py
+++ b/pyhomematic/devicetypes/actors.py
@@ -317,11 +317,18 @@ class IPSwitchPowermeter(IPSwitch, HMSensor):
         super().__init__(device_description, proxy, resolveparamsets)
 
         # init metadata
-        self.SENSORNODE.update({"POWER": [6],
-                                "CURRENT": [6],
-                                "VOLTAGE": [6],
-                                "FREQUENCY": [6],
-                                "ENERGY_COUNTER": [6]})
+        if "HmIP-FSM" in self.TYPE:
+            self.SENSORNODE.update({"POWER": [5],
+                                    "CURRENT": [5],
+                                    "VOLTAGE": [5],
+                                    "FREQUENCY": [5],
+                                    "ENERGY_COUNTER": [5]})
+        elif "HMIP-PSM" in self.TYPE:
+            self.SENSORNODE.update({"POWER": [6],
+                                    "CURRENT": [6],
+                                    "VOLTAGE": [6],
+                                    "FREQUENCY": [6],
+                                    "ENERGY_COUNTER": [6]})
 
 
 DEVICETYPES = {
@@ -431,6 +438,7 @@ DEVICETYPES = {
     "HMW-LC-Dim1L-DR": KeyDimmer,
     "HMIP-PS": IPSwitch,
     "HMIP-PSM": IPSwitchPowermeter,
+    "HmIP-FSM": IPSwitchPowermeter,
     "HMIP-BDT": IPKeyDimmer,
     "HmIP-BDT": IPKeyDimmer, # Version above did not work, keeping it though, just in case
     "HM-Sec-Key": KeyMatic,

--- a/pyhomematic/devicetypes/actors.py
+++ b/pyhomematic/devicetypes/actors.py
@@ -327,8 +327,7 @@ class IPSwitchPowermeter(IPSwitch, HMSensor):
             sensorIndex = 6
         elif "HmIP-BSM" in self.TYPE:
             sensorIndex = 7
-            
-            
+
         if sensorIndex is not None:
             self.SENSORNODE.update({"POWER": [sensorIndex],
                                     "CURRENT": [sensorIndex],

--- a/pyhomematic/devicetypes/actors.py
+++ b/pyhomematic/devicetypes/actors.py
@@ -272,7 +272,10 @@ class IPSwitch(GenericSwitch, HelperActionOnTime):
 
     @property
     def ELEMENT(self):
-        return [3]
+        if "HmIP-BSM" in self.TYPE:
+            return [4]
+        else:
+            return [3]
 
 
 class SwitchPowermeter(Switch, HelperActionOnTime, HMSensor):
@@ -317,18 +320,21 @@ class IPSwitchPowermeter(IPSwitch, HMSensor):
         super().__init__(device_description, proxy, resolveparamsets)
 
         # init metadata
+        sensorIndex = None
         if "HmIP-FSM" in self.TYPE:
-            self.SENSORNODE.update({"POWER": [5],
-                                    "CURRENT": [5],
-                                    "VOLTAGE": [5],
-                                    "FREQUENCY": [5],
-                                    "ENERGY_COUNTER": [5]})
+            sensorIndex = 5
         elif "HMIP-PSM" in self.TYPE:
-            self.SENSORNODE.update({"POWER": [6],
-                                    "CURRENT": [6],
-                                    "VOLTAGE": [6],
-                                    "FREQUENCY": [6],
-                                    "ENERGY_COUNTER": [6]})
+            sensorIndex = 6
+        elif "HmIP-BSM" in self.TYPE:
+            sensorIndex = 7
+            
+            
+        if sensorIndex is not None:
+            self.SENSORNODE.update({"POWER": [sensorIndex],
+                                    "CURRENT": [sensorIndex],
+                                    "VOLTAGE": [sensorIndex],
+                                    "FREQUENCY": [sensorIndex],
+                                    "ENERGY_COUNTER": [sensorIndex]})
 
 
 DEVICETYPES = {
@@ -439,6 +445,7 @@ DEVICETYPES = {
     "HMIP-PS": IPSwitch,
     "HMIP-PSM": IPSwitchPowermeter,
     "HmIP-FSM": IPSwitchPowermeter,
+    "HmIP-BSM": IPSwitchPowermeter,
     "HMIP-BDT": IPKeyDimmer,
     "HmIP-BDT": IPKeyDimmer, # Version above did not work, keeping it though, just in case
     "HM-Sec-Key": KeyMatic,


### PR DESCRIPTION
Product Pages:
FSM: http://www.eq-3.de/produkte/homematic-ip/licht/homematic-ip-dimmaktor-fuer-markenschalter-kopie.html
BSM: http://www.eq-3.de/produkte/homematic-ip/homematic-ip-schalt-mess-aktor-fuer-markenschalter.html

Ich bin mir jedoch nicht sicher ob die BSM Implementierung komplett ist. Das ein/ausschalten ist möglich und man bekommt auch die Energie Werte soweit ich jedoch weis sind die beiden Tasten auch noch mehrfachbelegbar mit eigenen scripts etc. das hab ich jetzt jedoch nicht berücksichtigt