### PR TITLE
Added support for HM-CC-VG-1 Groups

### DIFF
--- a/pyhomematic/_hm.py
+++ b/pyhomematic/_hm.py
@@ -19,6 +19,7 @@ LOCALPORT = 0
 REMOTES = {'default':
            {'ip': '127.0.0.1',
             'port': 2001,
+            'path': '',
             'username': 'Admin',
             'password': '',
             'resolvenames': False}}
@@ -459,16 +460,18 @@ class ServerThread(threading.Thread):
             except Exception as err:
                 LOG.warning("Skipping proxy: %s" % str(err))
                 continue
-            LOG.info("Creating proxy %s. Connecting to http://%s:%i" %
-                     (remote, host['ip'], host['port']))
+            if 'path' not in host:
+                host['path'] = ""
+            LOG.info("Creating proxy %s. Connecting to http://%s:%i%s" %
+                     (remote, host['ip'], host['port'], host['path']))
             host['id'] = "%s-%s" % (self._interface_id, remote)
             try:
-                self.proxies[host['id']] = LockingServerProxy("http://%s:%i" % (host['ip'], host['port']),
+                self.proxies[host['id']] = LockingServerProxy("http://%s:%i%s" % (host['ip'], host['port'], host['path']),
                                                               callbackip=host.get('callbackip', None),
                                                               callbackport=host.get('callbackport', None))
             except Exception as err:
-                LOG.warning("Failed connecting to proxy at http://%s:%i" %
-                            (host['ip'], host['port']))
+                LOG.warning("Failed connecting to proxy at http://%s:%i%s" %
+                            (host['ip'], host['port'], host['path']))
                 LOG.debug("__init__: Exception: %s" % str(err))
                 raise Exception
             try:

--- a/pyhomematic/devicetypes/thermostats.py
+++ b/pyhomematic/devicetypes/thermostats.py
@@ -103,6 +103,26 @@ class HMThermostat(HMDevice):
         return self.mode == self.LOWERING_MODE
 
 
+class ThermostatGroup(HMThermostat):
+    """
+    HM-CC-VG-1
+    Thermostatgroups made up out of multiple supported thermostats
+    """
+    def __init__(self, device_description, proxy, resolveparamsets=False):
+        super().__init__(device_description, proxy, resolveparamsets)
+
+        # init metadata
+        self.SENSORNODE.update({"ACTUAL_TEMPERATURE": [1]})
+        self.WRITENODE.update({"SET_TEMPERATURE": [1]})
+        self.ACTIONNODE.update({"AUTO_MODE": [1],
+                                "MANU_MODE": [1],
+                                "BOOST_MODE": [1],
+                                "COMFORT_MODE": [1],
+                                "LOWERING_MODE": [1]})
+        self.ATTRIBUTENODE.update({"VALVE_STATE": [1],
+                                   "CONTROL_MODE": [1]})
+
+
 class Thermostat(HMThermostat, HelperBatteryState, HelperValveState):
     """
     HM-CC-RT-DN, HM-CC-RT-DN-BoM
@@ -260,6 +280,7 @@ class IPThermostatWall(HMThermostat, HelperLowBatIP):
 
 
 DEVICETYPES = {
+    "HM-CC-VG-1": ThermostatGroup,
     "HM-CC-RT-DN": Thermostat,
     "HM-CC-RT-DN-BoM": Thermostat,
     "HM-TC-IT-WM-W-EU": ThermostatWall,


### PR DESCRIPTION
Added support for HM-CC-VG-1 Groups is requested in issue #43 .
It is expected that channel 1 always has the thermostat functionality. Are there setups where this is not the case?
The implementation for HASS is missing, currently. The `ThermostatGroup` class would need to be added, and we need some mechanism to enable the proxy. Either by having an extra host and generallyenabeling the path-setting, or automatically by setting something like `groups: true` on a specific host, which would then create an extra host with the different port and path. I would prefer to generally add the path-setting and having a full host in the hass-configuration.