### PR TITLE
Add support for 8 button remote control HmIP-RC8

### DIFF
--- a/pyhomematic/devicetypes/misc.py
+++ b/pyhomematic/devicetypes/misc.py
@@ -54,6 +54,8 @@ class Remote(HMEvent, HelperEventRemote, HelperActionPress):
             return [1, 2, 3, 4]
         if "HMW-IO-12-FM" in self.TYPE:
             return [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+        if "HmIP-RC8" in self.TYPE:
+            return [1, 2, 3, 4, 5, 6, 7, 8]
         return [1]
 
 
@@ -122,4 +124,5 @@ DEVICETYPES = {
     "263 144": RemotePress,
     "HM-SwI-X": RemotePress,
     "HMW-RCV-50": RemoteVirtual,
+    "HmIP-RC8": Remote,
 }


### PR DESCRIPTION
Works great with Home Assistant after this small change.

`2017-10-18 22:35:48 INFO (Thread-12) [pyhomematic.devicetypes.generic] HMGeneric.event: address=000B17099610A6:2, interface_id=homeassistant-HmIP, key=PRESS_SHORT, value=True
2017-10-18 22:35:48 INFO (MainThread) [homeassistant.core] Bus:Handling <Event homematic.keypress[L]: channel=2, name=remote1, param=PRESS_SHORT>
2017-10-18 22:35:48 INFO (MainThread) [homeassistant.components.automation] Executing remote1_2
`