### PR TITLE
Added HmIP-SPI

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 Version 0.1.35 (2017-11-nn)
 - Added HM-Dis-EP-WM55 @marconfus
 - Added HM-Sec-Sir-WM @danielperna84
+- Added HmIP-SPI @danielperna84
 
 Version 0.1.34 (2017-10-19)
 - Fixed HMIP-PSM @Munsio

--- a/pyhomematic/devicetypes/sensors.py
+++ b/pyhomematic/devicetypes/sensors.py
@@ -250,6 +250,7 @@ class MotionV2(Motion, HelperSabotage):
     """Motion detection version 2."""
     pass
 
+
 class MotionIP(HMBinarySensor, HMSensor):
     """Motion detection indoor (rf ip)"""
 
@@ -283,6 +284,41 @@ class MotionIP(HMBinarySensor, HMSensor):
     @property
     def ELEMENT(self):
         return [0, 1]
+
+
+class PresenceIP(HMBinarySensor, HMSensor):
+    """Presence detection with HmIP-SPI"""
+
+    def __init__(self, device_description, proxy, resolveparamsets=False):
+        super().__init__(device_description, proxy, resolveparamsets)
+
+        # init metadata
+        self.BINARYNODE.update({"PRESENCE_DETECTION_STATE": [1]})
+        self.SENSORNODE.update({"ILLUMINATION": [1]})
+        self.ATTRIBUTENODE.update({"LOW_BAT": [0],
+                                   "ERROR_CODE": [0],
+                                   "SABOTAGE": [0]})
+
+    def is_motion(self, channel=None):
+        """ Return True if motion is detected """
+        return bool(self.getBinaryData("PRESENCE_DETECTION_STATE", channel))
+
+    def get_brightness(self, channel=None):
+        """ Return brightness from 0 (dark) to 163830 (bright) """
+        return float(self.getSensorData("ILLUMINATION", channel))
+
+    def low_batt(self, channel=None):
+        """ Returns if the battery is low. """
+        return self.getAttributeData("LOW_BAT", channel)
+
+    def sabotage(self, channel=None):
+        """Returns True if the devicecase has been opened."""
+        return bool(self.getAttributeData("SABOTAGE", channel))
+
+    @property
+    def ELEMENT(self):
+        return [0, 1]
+
 
 class RemoteMotion(Remote, Motion):
     """Motion detection with buttons."""
@@ -466,6 +502,7 @@ DEVICETYPES = {
     "263 162": MotionV2,
     "HM-Sec-MD": MotionV2,
     "HmIP-SMI": MotionIP,
+    "HmIP-SPI": PresenceIP,
     "HM-Sen-LI-O": LuxSensor,
     "HM-Sen-EP": ImpulseSensor,
     "HM-Sen-X": ImpulseSensor,


### PR DESCRIPTION
Added HmIP-SPI.

Add `PresenceIP` in _homematic.py_ at `DISCOVER_SENSORS` and `DISCOVER_BINARY_SENSORS`. Additionally set class in _binary_sensor/homematic.py_ to `'motion'`.