### PR TITLE
added REV-Ritter-Switch

### DIFF
--- a/pyhomematic/devicetypes/actors.py
+++ b/pyhomematic/devicetypes/actors.py
@@ -449,6 +449,7 @@ DEVICETYPES = {
     "HM-LC-SwX": Switch,
     "HM-MOD-Re-8": Switch,
     "IT-Switch": Switch,
+    "REV-Ritter-Switch": Switch,
     "HM-ES-PMSw1-Pl": SwitchPowermeter,
     "HM-ES-PMSw1-Pl-DN-R1": SwitchPowermeter,
     "HM-ES-PMSw1-Pl-DN-R2": SwitchPowermeter,


### PR DESCRIPTION
This one is the second supported switch by homegear-intertechno.
With this patch it works in Home Assistant.