### PR TITLE
Refectoring of KeyMatic class

### DIFF
--- a/pyhomematic/devicetypes/actors.py
+++ b/pyhomematic/devicetypes/actors.py
@@ -270,9 +270,9 @@ class RFSiren(GenericSwitch, HelperWorking):
         return [1, 2, 3]
 
 
-class KeyMatic(GenericSwitch):
+class KeyMatic(HMActor, HelperActorState):
     """
-    Open or close KeyMatic.
+    Lock, Unlock or Open KeyMatic.
     """
     def __init__(self, device_description, proxy, resolveparamsets=False):
         super().__init__(device_description, proxy, resolveparamsets)
@@ -281,6 +281,30 @@ class KeyMatic(GenericSwitch):
         self.ACTIONNODE.update({"OPEN": self.ELEMENT})
         self.BINARYNODE.update({"STATE_UNCERTAIN": self.ELEMENT})
         self.SENSORNODE.update({"ERROR": self.ELEMENT})
+
+    def is_unlocked(self, channel=None):
+        """ Returns True if KeyMatic is unlocked. """
+        return self.get_state(channel)
+
+    def is_locked(self, channel=None):
+        """ Returns True if KeyMatic is locked. """
+        return not self.get_state(channel)
+
+    def unlock(self, channel=None):
+        """Unlocks the door lock."""
+        return self.set_state(True, channel)
+
+    def lock(self, channel=None):
+        """Locks the door lock"""
+        return self.set_state(False, channel)
+
+    def open(self):
+        """Opens the door.
+           Keep in mind that in most cases the door can only be closed physically.
+           If the KeyMatic is in locked state it will unlock first.
+           After opening the door the state of KeyMatic is unlocked.
+        """
+        return self.setValue("OPEN", True)
 
     @property
     def ELEMENT(self):

--- a/pyhomematic/devicetypes/helper.py
+++ b/pyhomematic/devicetypes/helper.py
@@ -95,9 +95,7 @@ class HelperSensorState(HMDevice):
 
 
 class HelperActorState(HMDevice):
-    """
-    Generic HM Switch Object
-    """
+    """Return the binary state of an actor."""
     def __init__(self, device_description, proxy, resolveparamsets=False):
         super().__init__(device_description, proxy, resolveparamsets)
 
@@ -105,15 +103,15 @@ class HelperActorState(HMDevice):
         self.WRITENODE.update({"STATE": self.ELEMENT})
 
     def get_state(self, channel=None):
-        """ Returns if switch is 'on' or 'off'. """
+        """ Returns if state is 'on' or 'off'. """
         return bool(self.getWriteData("STATE", channel))
 
     def set_state(self, onoff, channel=None):
-        """Turn switch on/off"""
+        """Turn state on/off"""
         try:
             onoff = bool(onoff)
         except Exception as err:
-            LOG.debug("HelperSwitch.set_state: Exception %s" % (err,))
+            LOG.debug("HelperActorState.set_state: Exception %s" % (err,))
             return False
 
         self.writeNodeData("STATE", onoff, channel)


### PR DESCRIPTION
- Class KeyMatic now inherits from HMActor and implements HelperActorState, since this actor differs from a GenericSwitch (2 buttons, 2 states). It is in fact a switch with 3 buttons and 2 states
- Adding high-level methods in KeyMatic class for easier access to the core features of the KeyMatic (Lock, Unlock and Open).
- Changes some doc strings in HelperActorState, since read/write binary states can be found also on other components then switches.