### PR TITLE
Fix skipping remotes

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 Version 0.1.38 (2018-01-)
  - KeyMatic improvements @PH89
+ - Fix skipping remotes @danielperna84
 
 Version 0.1.37 (2018-01-11)
 - Allow skipping remotes @pvizeli


### PR DESCRIPTION
Apparantly service messages haven't been available since skipping remotes (`connect` parameter) was implemented. The reason is, that to fetch service messages a proxy object is needed. If `connect` was set to `False` the proxy wasn't created, which is the case for every HMHub-entity / host that is not part of the `interfaces` part of the HASS configuration.