### PR TITLE
Add HmIP-SRH rotary handle sensor to device list

### DIFF
--- a/pyhomematic/devicetypes/sensors.py
+++ b/pyhomematic/devicetypes/sensors.py
@@ -479,6 +479,7 @@ DEVICETYPES = {
     "HM-SCI-3-FM": IPShutterContact,
     "HMIP-SWDO": IPShutterContact,
     "HmIP-SWDO": IPShutterContact,
+    "HmIP-SRH": RotaryHandleSensor,
     "HM-Sec-RHS": RotaryHandleSensor,
     "ZEL STG RM FDK": RotaryHandleSensor,
     "HM-Sec-RHS-2": RotaryHandleSensor,


### PR DESCRIPTION
Adding support for http://www.eq-3.com/products/homematic-ip/homematic-ip-window-handle-sensor.html