### PR TITLE
Add optional port for resolvenames via JSON

### DIFF
--- a/pyhomematic/_hm.py
+++ b/pyhomematic/_hm.py
@@ -267,8 +267,9 @@ class RPCFunctions(object):
             headers = {"Content-Type": 'application/json',
                        "Content-Length": len(payload)}
             if jsonport:
-                jsonport = ":"+jsonport
-            apiendpoint = "http://%s%s%s" % (host, jsonport, JSONRPC_URL)
+                apiendpoint = "http://%s:%s%s" % (host, jsonport, JSONRPC_URL)
+            else:
+                apiendpoint = "http://%s%s" % (host, JSONRPC_URL)
             LOG.debug("RPCFunctions.jsonRpcPost: API-Endpoint: %s" %
                       apiendpoint)
             req = urllib.request.Request(apiendpoint, payload, headers)

--- a/pyhomematic/_hm.py
+++ b/pyhomematic/_hm.py
@@ -23,6 +23,7 @@ REMOTES = {
         'path': '',
         'username': 'Admin',
         'password': '',
+        'jsonport': 80,
         'resolvenames': False,
         'connect': True,
     }}
@@ -266,10 +267,7 @@ class RPCFunctions(object):
 
             headers = {"Content-Type": 'application/json',
                        "Content-Length": len(payload)}
-            if jsonport:
-                apiendpoint = "http://%s:%s%s" % (host, jsonport, JSONRPC_URL)
-            else:
-                apiendpoint = "http://%s%s" % (host, JSONRPC_URL)
+            apiendpoint = "http://%s:%s%s" % (host, jsonport, JSONRPC_URL)
             LOG.debug("RPCFunctions.jsonRpcPost: API-Endpoint: %s" %
                       apiendpoint)
             req = urllib.request.Request(apiendpoint, payload, headers)

--- a/pyhomematic/_hm.py
+++ b/pyhomematic/_hm.py
@@ -258,7 +258,7 @@ class RPCFunctions(object):
             self.systemcallback('readdedDevice', interface_id, addresses)
         return True
 
-    def jsonRpcPost(self, host, method, params={}):
+    def jsonRpcPost(self, host, jsonport, method, params={}):
         LOG.debug("RPCFunctions.jsonRpcPost: Method: %s" % method)
         try:
             payload = json.dumps(
@@ -266,7 +266,9 @@ class RPCFunctions(object):
 
             headers = {"Content-Type": 'application/json',
                        "Content-Length": len(payload)}
-            apiendpoint = "http://%s%s" % (host, JSONRPC_URL)
+            if jsonport:
+                jsonport = ":"+jsonport
+            apiendpoint = "http://%s%s%s" % (host, jsonport, JSONRPC_URL)
             LOG.debug("RPCFunctions.jsonRpcPost: API-Endpoint: %s" %
                       apiendpoint)
             req = urllib.request.Request(apiendpoint, payload, headers)
@@ -312,7 +314,7 @@ class RPCFunctions(object):
                 params = {"username": self.remotes[remote][
                     'username'], "password": self.remotes[remote]['password']}
                 response = self.jsonRpcPost(
-                    self.remotes[remote]['ip'], "Session.login", params)
+                    self.remotes[remote]['ip'], self.remotes[remote]['jsonport'], "Session.login", params)
                 if response['error'] is None and response['result']:
                     session = response['result']
 
@@ -323,7 +325,7 @@ class RPCFunctions(object):
 
                 params = {"_session_id_": session}
                 response = self.jsonRpcPost(
-                    self.remotes[remote]['ip'], "Interface.listInterfaces", params)
+                    self.remotes[remote]['ip'], self.remotes[remote]['jsonport'], "Interface.listInterfaces", params)
                 interface = False
                 if response['error'] is None and response['result']:
                     for i in response['result']:
@@ -335,12 +337,12 @@ class RPCFunctions(object):
                 if not interface:
                     params = {"_session_id_": session}
                     response = self.jsonRpcPost(
-                        self.remotes[remote]['ip'], "Session.logout", params)
+                        self.remotes[remote]['ip'], self.remotes[remote]['jsonport'], "Session.logout", params)
                     return
 
                 params = {"_session_id_": session}
                 response = self.jsonRpcPost(
-                    self.remotes[remote]['ip'], "Device.listAllDetail", params)
+                    self.remotes[remote]['ip'], self.remotes[remote]['jsonport'], "Device.listAllDetail", params)
 
                 if response['error'] is None and response['result']:
                     LOG.debug(
@@ -356,11 +358,11 @@ class RPCFunctions(object):
 
                 params = {"_session_id_": session}
                 response = self.jsonRpcPost(
-                    self.remotes[remote]['ip'], "Session.logout", params)
+                    self.remotes[remote]['ip'], self.remotes[remote]['jsonport'], "Session.logout", params)
             except Exception as err:
                 params = {"_session_id_": session}
                 response = self.jsonRpcPost(
-                    self.remotes[remote]['ip'], "Session.logout", params)
+                    self.remotes[remote]['ip'], self.remotes[remote]['jsonport'], "Session.logout", params)
                 LOG.warning(
                     "RPCFunctions.addDeviceNames: Exception: %s" % str(err))
 
@@ -596,7 +598,7 @@ class ServerThread(threading.Thread):
             params = {"username": self.remotes[remote][
                 'username'], "password": self.remotes[remote]['password']}
             response = self._rpcfunctions.jsonRpcPost(
-                self.remotes[remote]['ip'], "Session.login", params)
+                self.remotes[remote]['ip'], self.remotes[remote]['jsonport'], "Session.login", params)
             if response['error'] is None and response['result']:
                 session = response['result']
 
@@ -614,7 +616,7 @@ class ServerThread(threading.Thread):
         try:
             params = {"_session_id_": session}
             response = self._rpcfunctions.jsonRpcPost(
-                self.remotes[remote]['ip'], "Session.logout", params)
+                self.remotes[remote]['ip'], self.remotes[remote]['jsonport'], "Session.logout", params)
             if response['error'] is None and response['result']:
                 logout = response['result']
         except Exception as err:
@@ -634,7 +636,7 @@ class ServerThread(threading.Thread):
             try:
                 params = {"_session_id_": session}
                 response = self._rpcfunctions.jsonRpcPost(
-                    self.remotes[remote]['ip'], "SysVar.getAll", params)
+                    self.remotes[remote]['ip'], self.remotes[remote]['jsonport'], "SysVar.getAll", params)
                 if response['error'] is None and response['result']:
                     for var in response['result']:
                         key, value = self.parseCCUSysVar(var)
@@ -666,7 +668,7 @@ class ServerThread(threading.Thread):
             try:
                 params = {"_session_id_": session, "name": name}
                 response = self._rpcfunctions.jsonRpcPost(
-                    self.remotes[remote]['ip'], "SysVar.getValueByName", params)
+                    self.remotes[remote]['ip'], self.remotes[remote]['jsonport'], "SysVar.getValueByName", params)
                 if response['error'] is None and response['result']:
                     try:
                         var = float(response['result'])
@@ -698,7 +700,7 @@ class ServerThread(threading.Thread):
             try:
                 params = {"_session_id_": session, "name": name}
                 response = self._rpcfunctions.jsonRpcPost(
-                    self.remotes[remote]['ip'], "SysVar.deleteSysVarByName", params)
+                    self.remotes[remote]['ip'], self.remotes[remote]['jsonport'], "SysVar.deleteSysVarByName", params)
                 if response['error'] is None and response['result']:
                     deleted = response['result']
                     LOG.warning(
@@ -730,10 +732,10 @@ class ServerThread(threading.Thread):
                 if value is True or value is False:
                     params['value'] = int(value)
                     response = self._rpcfunctions.jsonRpcPost(
-                        self.remotes[remote]['ip'], "SysVar.setBool", params)
+                        self.remotes[remote]['ip'], self.remotes[remote]['jsonport'], "SysVar.setBool", params)
                 else:
                     response = self._rpcfunctions.jsonRpcPost(
-                        self.remotes[remote]['ip'], "SysVar.setFloat", params)
+                        self.remotes[remote]['ip'], self.remotes[remote]['jsonport'], "SysVar.setFloat", params)
                 if response['error'] is None and response['result']:
                     res = response['result']
                     LOG.debug(


### PR DESCRIPTION
Allow configuration for non-standard HTTP port (e.g. when running CCU2 virtually on the same machine via docker image, and port cannot be 80).