### PR TITLE
Fix RSSI reporting

### DIFF
--- a/manual_test.py
+++ b/manual_test.py
@@ -140,7 +140,7 @@ def cli(local, localport, remote, remoteport, address, channel, state, toggle,
                 print(" / Switch is on: %s" % str(device.is_on(channel)))
 
         ########### Attribute #########
-        print(" / RSSI_DEVICE: %i" % device.get_rssi())
+        print(" / RSSI_PEER: %i" % device.get_rssi())
 
         if isinstance(device, HelperLowBat):
             print(" / Low batter: %s" % str(device.low_batt()))

--- a/pyhomematic/devicetypes/generic.py
+++ b/pyhomematic/devicetypes/generic.py
@@ -213,7 +213,7 @@ class HMDevice(HMGeneric):
         # - 0...n / getValue from channel (fix)
         self._SENSORNODE = {}
         self._BINARYNODE = {}
-        self._ATTRIBUTENODE = {"RSSI_DEVICE": [0]}
+        self._ATTRIBUTENODE = {"RSSI_PEER": [0]}
         self._WRITENODE = {}
         self._EVENTNODE = {}
         self._ACTIONNODE = {}
@@ -334,7 +334,7 @@ class HMDevice(HMGeneric):
         return False
 
     def get_rssi(self, channel=0):
-        return self.getAttributeData("RSSI_DEVICE", channel)
+        return self.getAttributeData("RSSI_PEER", channel)
 
     @property
     def ELEMENT(self):

--- a/pyhomematic/devicetypes/helper.py
+++ b/pyhomematic/devicetypes/helper.py
@@ -238,8 +238,8 @@ class HelperEventRemote(HMDevice):
                                "PRESS_LONG_RELEASE": self.ELEMENT})
 
 class HelperWired(HMDevice):
-    """Remove the RSSI_DEVICE attribute"""
+    """Remove the RSSI_PEER attribute"""
     def __init__(self, device_description, proxy, resolveparamsets=False):
         super().__init__(device_description, proxy, resolveparamsets)
 
-        self.ATTRIBUTENODE.pop("RSSI_DEVICE", None)
+        self.ATTRIBUTENODE.pop("RSSI_PEER", None)

--- a/pyhomematic/devicetypes/sensors.py
+++ b/pyhomematic/devicetypes/sensors.py
@@ -535,7 +535,7 @@ class IPPassageSensor(HMSensor, HMBinarySensor, HelperEventRemote, HelperLowBatI
         self.BINARYNODE.update({"PASSAGE_COUNTER_OVERFLOW": self.ELEMENT,
                                 "LAST_PASSAGE_DIRECTION": [2],
                                 "CURRENT_PASSAGE_DIRECTION": [2]})
-        self.ATTRIBUTENODE.update({"RSSI_DEVICE": [0]})
+        self.ATTRIBUTENODE.update({"RSSI_PEER": [0]})
 
     @property
     def ELEMENT(self):


### PR DESCRIPTION
For RSSI values we should read `RSSI_PEER` instead of `RSSI_DEVICE`.

See danielperna84/pyhomematic#155