### PR TITLE
Change XML API URL

### DIFF
--- a/pyhomematic/_hm.py
+++ b/pyhomematic/_hm.py
@@ -30,7 +30,7 @@ REMOTES = {
     }}
 DEVICEFILE = False  # e.g. devices.json
 INTERFACE_ID = 'pyhomematic'
-XML_API_URL = '/config/xmlapi/devicelist.cgi'
+XML_API_URL = '/addons/xmlapi/devicelist.cgi'
 JSONRPC_URL = '/api/homematic.cgi'
 BACKEND_UNKNOWN = 0
 BACKEND_CCU = 1


### PR DESCRIPTION
While looking at https://github.com/hobbyquaker/XML-API/blob/master/README.md#use, I think this should be changed.

I am completely new to home-assistant and homematic, so sorry if I might be wrong.