### PR TITLE
Rework RSSI handling

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,43 @@
+---
+name: Bug report
+about: Create a report to help us improve
+
+---
+
+Make sure you are running the latest version of pyhomematic (and Home Assistant) before reporting an issue.
+
+_If you encounter the problem when using Home Assistant, please fill out the following information_
+
+**Home Assistant version (if applicable):**
+0.n.n
+
+**Problem-relevant `configuration.yaml` entries and steps to reproduce:**
+```yaml
+
+```
+
+Use the following configuration for debug-output of the related components:
+```yaml
+logs:
+  homeassistant.components.homematic: debug
+  pyhomematic: debug
+```
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please point your pull request at the __devel__ branch. Also provide information some information about the changes.
+
+This pull request:
+- fixes issue: \<Link to issue>
+- adds support for HomeMatic device: \<Device name goes here, e.g. HmIP-ABC-DEF>
+  - New class: \<e.g. YourSensor>
+  - Home Assistant [platform](https://github.com/home-assistant/home-assistant/blob/0da3e737651a150c17016f43b5f9144deff7ddd7/homeassistant/components/homematic/__init__.py#L65): \<e.g. `DISCOVER_LIGHTS`>
+- does the following: \<Description of what the change is intended to do>

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-Please point your pull request at the __devel__ branch. Also provide information some information about the changes.
+Please point your pull request at the __devel__ branch. Also provide some information about the changes.
 
 This pull request:
 - fixes issue: \<Link to issue>

--- a/pyhomematic/devicetypes/actors.py
+++ b/pyhomematic/devicetypes/actors.py
@@ -4,7 +4,7 @@ from pyhomematic.devicetypes.sensors import HMSensor
 from pyhomematic.devicetypes.misc import HMEvent
 from pyhomematic.devicetypes.helper import (
     HelperWorking, HelperActorState, HelperActorLevel, HelperActorBlindTilt, HelperActionOnTime,
-    HelperActionPress, HelperEventRemote, HelperWired)
+    HelperActionPress, HelperEventRemote, HelperWired, HelperRssiPeer)
 
 LOG = logging.getLogger(__name__)
 
@@ -34,7 +34,7 @@ class GenericBlind(HMActor, HelperActorLevel):
         self.actionNodeData("STOP", True, channel)
 
 
-class Blind(GenericBlind, HelperWorking):
+class Blind(GenericBlind, HelperWorking, HelperRssiPeer):
     """
     Blind switch that raises and lowers roller shutters or window blinds.
     """
@@ -174,7 +174,7 @@ class Rain(GenericSwitch, HelperWorking):
         return [2]
 
 
-class Switch(GenericSwitch, HelperWorking):
+class Switch(GenericSwitch, HelperWorking, HelperRssiPeer):
     """
     Switch turning plugged in device on or off.
     """
@@ -268,7 +268,7 @@ class HMWIOSwitch(GenericSwitch, HelperWired):
         return self._doc
 
 
-class RFSiren(GenericSwitch, HelperWorking):
+class RFSiren(GenericSwitch, HelperWorking, HelperRssiPeer):
     """
     HM-Sec-Sir-WM Siren
     """

--- a/pyhomematic/devicetypes/generic.py
+++ b/pyhomematic/devicetypes/generic.py
@@ -59,9 +59,6 @@ class HMGeneric():
             % (self._ADDRESS, interface_id, key, value))
         if key == PARAM_UNREACH:
             self._unreach = value
-        if not self._eventcallbacks:
-            LOG.debug("HMGeneric.event: No callbacks registered for event %s (%s)", key, str(self))
-
         for callback in self._eventcallbacks:
             LOG.debug("HMDevice.event: Using callback %s " % str(callback))
             callback(self._ADDRESS, interface_id, key, value)
@@ -355,14 +352,9 @@ class HMDevice(HMGeneric):
         Signature for callback-functions: foo(address, interface_id, key, value)
         """
         if hasattr(callback, '__call__'):
-            LOG.debug(
-                "Adding callback '%s' for %s:%s (%s)",
-                str(callback), self._name, channel, str(self)
-            )
-
             if channel == 0:
                 self._eventcallbacks.append(callback)
-            if not bequeath and channel in self._hmchannels:
+            elif not bequeath and channel > 0 and channel in self._hmchannels:
                 self._hmchannels[channel]._eventcallbacks.append(callback)
             if bequeath:
                 for channel, device in self._hmchannels.items():

--- a/pyhomematic/devicetypes/generic.py
+++ b/pyhomematic/devicetypes/generic.py
@@ -213,7 +213,7 @@ class HMDevice(HMGeneric):
         # - 0...n / getValue from channel (fix)
         self._SENSORNODE = {}
         self._BINARYNODE = {}
-        self._ATTRIBUTENODE = {"RSSI_PEER": [0]}
+        self._ATTRIBUTENODE = {}
         self._WRITENODE = {}
         self._EVENTNODE = {}
         self._ACTIONNODE = {}
@@ -334,7 +334,13 @@ class HMDevice(HMGeneric):
         return False
 
     def get_rssi(self, channel=0):
-        return self.getAttributeData("RSSI_PEER", channel)
+        """
+        This is a stub method which is implemented by the helpers
+        HelperRssiPeer/HelperRssiDevice in order to provide a suitable
+        implementation for the device.
+        """
+        #pylint: disable=unused-argument
+        return 0
 
     @property
     def ELEMENT(self):

--- a/pyhomematic/devicetypes/helper.py
+++ b/pyhomematic/devicetypes/helper.py
@@ -238,8 +238,28 @@ class HelperEventRemote(HMDevice):
                                "PRESS_LONG_RELEASE": self.ELEMENT})
 
 class HelperWired(HMDevice):
-    """Remove the RSSI_PEER attribute"""
+    """Remove the RSSI-related attributes"""
     def __init__(self, device_description, proxy, resolveparamsets=False):
         super().__init__(device_description, proxy, resolveparamsets)
-
         self.ATTRIBUTENODE.pop("RSSI_PEER", None)
+        self.ATTRIBUTENODE.pop("RSSI_DEVICE", None)
+
+
+class HelperRssiDevice(HMDevice):
+    """Used for devices which report their RSSI value through RSSI_DEVICE"""
+    def __init__(self, device_description, proxy, resolveparamsets=False):
+        super().__init__(device_description, proxy, resolveparamsets)
+        self.ATTRIBUTENODE["RSSI_DEVICE"] = [0]
+
+    def get_rssi(self, channel=0):
+        return self.getAttributeData("RSSI_DEVICE", channel)
+
+
+class HelperRssiPeer(HMDevice):
+    """Used for devices which report their RSSI value through RSSI_PEER"""
+    def __init__(self, device_description, proxy, resolveparamsets=False):
+        super().__init__(device_description, proxy, resolveparamsets)
+        self.ATTRIBUTENODE["RSSI_PEER"] = [0]
+
+    def get_rssi(self, channel=0):
+        return self.getAttributeData("RSSI_PEER", channel)

--- a/pyhomematic/devicetypes/misc.py
+++ b/pyhomematic/devicetypes/misc.py
@@ -1,6 +1,6 @@
 import logging
 from pyhomematic.devicetypes.generic import HMDevice
-from pyhomematic.devicetypes.helper import HelperActionPress, HelperEventRemote, HelperEventPress
+from pyhomematic.devicetypes.helper import HelperActionPress, HelperEventRemote, HelperEventPress, HelperRssiPeer
 
 LOG = logging.getLogger(__name__)
 
@@ -21,7 +21,7 @@ class RemoteVirtual(HMCCU, HelperEventRemote, HelperActionPress):
         return [c for c in range(1, 51)]
 
 
-class Remote(HMEvent, HelperEventRemote, HelperActionPress):
+class Remote(HMEvent, HelperEventRemote, HelperActionPress, HelperRssiPeer):
     """Remote handle buttons."""
 
     @property

--- a/pyhomematic/devicetypes/sensors.py
+++ b/pyhomematic/devicetypes/sensors.py
@@ -5,7 +5,7 @@ from pyhomematic.devicetypes.helper import (HelperLowBat, HelperSabotage,
                                             HelperLowBatIP, HelperSabotageIP,
                                             HelperBinaryState,
                                             HelperSensorState,
-                                            HelperWired, HelperEventRemote)
+                                            HelperWired, HelperEventRemote, HelperRssiPeer, HelperRssiDevice)
 
 LOG = logging.getLogger(__name__)
 
@@ -35,7 +35,7 @@ class IPShutterContact(HMBinarySensor, HelperBinaryState, HelperLowBat):
         return [1]
 
 
-class ShutterContact(IPShutterContact, HelperSabotage):
+class ShutterContact(IPShutterContact, HelperSabotage, HelperRssiPeer):
     """Door / Window contact that emits its open/closed state."""
     pass
 
@@ -60,7 +60,7 @@ class TiltSensor(HMBinarySensor, HelperBinaryState, HelperLowBat):
         return not self.get_state(channel)
 
 
-class RotaryHandleSensor(HMSensor, HelperSensorState, HelperLowBat, HelperSabotage):
+class RotaryHandleSensor(HMSensor, HelperSensorState, HelperLowBat, HelperSabotage, HelperRssiPeer):
     """Window handle contact."""
     def is_open(self, channel=None):
         """ Returns True if the handle is set to open. """
@@ -105,7 +105,7 @@ class CO2Sensor(HMSensor, HelperSensorState):
         return self.get_state(channel) == 2
 
 
-class WaterSensor(HMSensor, HelperSensorState, HelperLowBat):
+class WaterSensor(HMSensor, HelperSensorState, HelperLowBat, HelperRssiPeer):
     """Watter detect sensor."""
 
     def is_dry(self, channel=None):
@@ -121,7 +121,7 @@ class WaterSensor(HMSensor, HelperSensorState, HelperLowBat):
         return self.get_state(channel) == 2
 
 
-class PowermeterGas(HMSensor):
+class PowermeterGas(HMSensor, HelperRssiPeer):
     """Powermeter for Gas and energy."""
 
     def __init__(self, device_description, proxy, resolveparamsets=False):
@@ -167,7 +167,7 @@ class SmokeV2(Smoke, HelperLowBat):
                                    "ERROR_SMOKE_CHAMBER": self.ELEMENT})
 
 
-class IPSmoke(HMSensor):
+class IPSmoke(HMSensor, HelperRssiDevice):
     """HomeMatic IP Smoke sensor"""
 
     def __init__(self, device_description, proxy, resolveparamsets=False):

--- a/pyhomematic/devicetypes/thermostats.py
+++ b/pyhomematic/devicetypes/thermostats.py
@@ -1,7 +1,7 @@
 import logging
 from pyhomematic.devicetypes.generic import HMDevice
 from pyhomematic.devicetypes.sensors import AreaThermostat
-from pyhomematic.devicetypes.helper import HelperValveState, HelperBatteryState, HelperLowBat, HelperLowBatIP
+from pyhomematic.devicetypes.helper import HelperValveState, HelperBatteryState, HelperLowBat, HelperLowBatIP, HelperRssiPeer
 
 LOG = logging.getLogger(__name__)
 
@@ -123,7 +123,7 @@ class ThermostatGroup(HMThermostat):
                                    "CONTROL_MODE": [1]})
 
 
-class Thermostat(HMThermostat, HelperBatteryState, HelperValveState):
+class Thermostat(HMThermostat, HelperBatteryState, HelperValveState, HelperRssiPeer):
     """
     HM-CC-RT-DN, HM-CC-RT-DN-BoM
     ClimateControl-Radiator Thermostat that measures temperature and allows to set a target temperature or use some automatic mode.
@@ -144,7 +144,7 @@ class Thermostat(HMThermostat, HelperBatteryState, HelperValveState):
                                    "CONTROL_MODE": [4]})
 
 
-class ThermostatWall(HMThermostat, AreaThermostat, HelperBatteryState):
+class ThermostatWall(HMThermostat, AreaThermostat, HelperBatteryState, HelperRssiPeer):
     """
     HM-TC-IT-WM-W-EU
     ClimateControl-Wall Thermostat that measures temperature and allows to set a target temperature or use some automatic mode.

--- a/tests/test_pyhomematic.py
+++ b/tests/test_pyhomematic.py
@@ -8,6 +8,7 @@ import json
 from pyhomematic import vccu
 from pyhomematic import HMConnection
 from pyhomematic import devicetypes
+from pyhomematic.devicetypes.helper import HelperRssiDevice, HelperRssiPeer
 
 logging.basicConfig(level=logging.INFO)
 LOG = logging.getLogger(__name__)
@@ -144,6 +145,28 @@ class Test_2_PyhomematicDevices(unittest.TestCase):
                     LOG.info("Unsupported device: %s" % deviceobject.TYPE)
                 else:
                     LOG.warning("Device class missing for: %s" % deviceobject.TYPE)
+
+
+class Test_3_HelperClassHierarchy(unittest.TestCase):
+    """
+    Some helper classes are mutally exclusive (such as HelperRssiPeer/HelperRssiDevice).
+
+    Since many device implementations inherit from other implementation classes we need
+    to be extra careful when plugging in such mutally excluse helpers somewhere in the
+    class hierarchy. This test case may be used for checking the currently available device
+    classes for such situations.
+    """
+    def setUp(self):
+        self.device_classes = set(devicetypes.SUPPORTED.values())
+
+    def test_rssi_helper(self):
+        for klass in self.device_classes:
+            both_rssi_helpers_used = issubclass(HelperRssiDevice, klass) and issubclass(HelperRssiPeer, klass)
+            self.assertFalse(
+                both_rssi_helpers_used, 
+                "The class %s inherits from both HelperRssiDevice and HelperRssiPeer, which is not supported." % klass
+            )
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Some devices use RSSI_PEER and some use RSSI_DEVICE for reporting RSSI values. The attribute which is used for the lookup can now be controlled through a helper class in the device implementation.

This may break RSSI reporting for untested devices!

See danielperna84/pyhomematic#164

