### PR TITLE
0.1.48

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 Version 0.1.48 (2018-)
 - Added Support for HmIP-SWO-PL and HmIP-SWO-B @dickesW
+- Fix callbacks for channel 0 @klada
 
 Version 0.1.47 (2018-08-20)
 - Fix HmIP-BWTH (Issue #151) @danielperna84

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,5 @@
 Version 0.1.48 (2018-)
-- 
+- Added Support for HmIP-SWO-PL and HmIP-SWO-B @dickesW
 
 Version 0.1.47 (2018-08-20)
 - Fix HmIP-BWTH (Issue #151) @danielperna84

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+Version 0.1.48 (2018-)
+- 
+
 Version 0.1.47 (2018-08-20)
 - Fix HmIP-BWTH (Issue #151) @danielperna84
 - Added HmIP-KRCA @danielperna84

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,4 @@
-Version 0.1.48 (2018-)
+Version 0.1.48 (2018-09-13)
 - Added Support for HmIP-SWO-PL and HmIP-SWO-B @dickesW
 - Fix callbacks for channel 0 @klada
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ def readme():
 
 PACKAGE_NAME = 'pyhomematic'
 HERE = os.path.abspath(os.path.dirname(__file__))
-VERSION = '0.1.47'
+VERSION = '0.1.48'
 
 PACKAGES = find_packages(exclude=['tests', 'tests.*', 'dist', 'build'])
 


### PR DESCRIPTION
- Added Support for HmIP-SWO-PL and HmIP-SWO-B
- Fix callbacks for channel 0

Changes required in Home Assistant:
Add `IPWeatherSensorPlus` and `IPWeatherSensorBasic` as sensor-classes.