### PR TITLE
0.1.49

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,43 @@
+---
+name: Bug report
+about: Create a report to help us improve
+
+---
+
+Make sure you are running the latest version of pyhomematic (and Home Assistant) before reporting an issue.
+
+_If you encounter the problem when using Home Assistant, please fill out the following information_
+
+**Home Assistant version (if applicable):**
+0.n.n
+
+**Problem-relevant `configuration.yaml` entries and steps to reproduce:**
+```yaml
+
+```
+
+Use the following configuration for debug-output of the related components:
+```yaml
+logs:
+  homeassistant.components.homematic: debug
+  pyhomematic: debug
+```
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please point your pull request at the __devel__ branch. Also provide some information about the changes.
+
+This pull request:
+- fixes issue: \<Link to issue>
+- adds support for HomeMatic device: \<Device name goes here, e.g. HmIP-ABC-DEF>
+  - New class: \<e.g. YourSensor>
+  - Home Assistant [platform](https://github.com/home-assistant/home-assistant/blob/0da3e737651a150c17016f43b5f9144deff7ddd7/homeassistant/components/homematic/__init__.py#L65): \<e.g. `DISCOVER_LIGHTS`>
+- does the following: \<Description of what the change is intended to do>

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 Version 0.1.48 (2018-)
 - Added Support for HmIP-SWO-PL and HmIP-SWO-B @dickesW
+- Fix callbacks for channel 0 @klada
 
 Version 0.1.47 (2018-08-20)
 - Fix HmIP-BWTH (Issue #151) @danielperna84

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,5 @@
+Version 0.1.48 (2018-)
+
 Version 0.1.48 (2018-09-13)
 - Added Support for HmIP-SWO-PL and HmIP-SWO-B @dickesW
 - Fix callbacks for channel 0 @klada

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,5 @@
 Version 0.1.48 (2018-)
-- 
+- Added Support for HmIP-SWO-PL and HmIP-SWO-B @dickesW
 
 Version 0.1.47 (2018-08-20)
 - Fix HmIP-BWTH (Issue #151) @danielperna84

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+Version 0.1.48 (2018-)
+- 
+
 Version 0.1.47 (2018-08-20)
 - Fix HmIP-BWTH (Issue #151) @danielperna84
 - Added HmIP-KRCA @danielperna84

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,5 @@
-Version 0.1.48 (2018-09-)
-- Rework RSSI handling (Issue #164) @klada
+Version 0.1.49 (2018-09-16)
+- Rework RSSI handling (Issue #164, Issue #121) @klada
 - Prevent failure of everything when single host is down (Issue #162)
 
 Version 0.1.48 (2018-09-13)

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,4 @@
-Version 0.1.48 (2018-)
+Version 0.1.48 (2018-09-13)
 - Added Support for HmIP-SWO-PL and HmIP-SWO-B @dickesW
 - Fix callbacks for channel 0 @klada
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 Version 0.1.48 (2018-09-)
 - Rework RSSI handling (Issue #164) @klada
+- Prevent failure of everything when single host is down (Issue #162)
 
 Version 0.1.48 (2018-09-13)
 - Added Support for HmIP-SWO-PL and HmIP-SWO-B @dickesW

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,8 @@
+Version 0.1.47 (2018-08-20)
+- Fix HmIP-BWTH (Issue #151) @danielperna84
+- Added HmIP-KRCA @danielperna84
+- Fix RSSI reporting (Issue #155) @klada
+
 Version 0.1.46 (2018-07-21)
 - Added PRESS event for HmIP-BSM @ToSa27
 - Added Smartware Motion Detector @maxm87

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,5 @@
-Version 0.1.48 (2018-)
+Version 0.1.48 (2018-09-)
+- Rework RSSI handling (Issue #164) @klada
 
 Version 0.1.48 (2018-09-13)
 - Added Support for HmIP-SWO-PL and HmIP-SWO-B @dickesW

--- a/manual_test.py
+++ b/manual_test.py
@@ -140,7 +140,7 @@ def cli(local, localport, remote, remoteport, address, channel, state, toggle,
                 print(" / Switch is on: %s" % str(device.is_on(channel)))
 
         ########### Attribute #########
-        print(" / RSSI_DEVICE: %i" % device.get_rssi())
+        print(" / RSSI_PEER: %i" % device.get_rssi())
 
         if isinstance(device, HelperLowBat):
             print(" / Low batter: %s" % str(device.low_batt()))

--- a/pyhomematic/devicetypes/actors.py
+++ b/pyhomematic/devicetypes/actors.py
@@ -4,7 +4,7 @@ from pyhomematic.devicetypes.sensors import HMSensor
 from pyhomematic.devicetypes.misc import HMEvent
 from pyhomematic.devicetypes.helper import (
     HelperWorking, HelperActorState, HelperActorLevel, HelperActorBlindTilt, HelperActionOnTime,
-    HelperActionPress, HelperEventRemote, HelperWired, HelperRssiPeer)
+    HelperActionPress, HelperEventRemote, HelperWired, HelperRssiPeer, HelperRssiDevice)
 
 LOG = logging.getLogger(__name__)
 
@@ -377,7 +377,7 @@ class EcoLogic(Switch, HelperActionOnTime, HelperActionPress, HMSensor):
         return [1, 2]
 
 
-class IPSwitchPowermeter(IPSwitch, HMSensor):
+class IPSwitchPowermeter(IPSwitch, HMSensor, HelperRssiDevice):
     """
     Switch turning plugged in device on or off and measuring energy consumption.
     """

--- a/pyhomematic/devicetypes/actors.py
+++ b/pyhomematic/devicetypes/actors.py
@@ -4,7 +4,7 @@ from pyhomematic.devicetypes.sensors import HMSensor
 from pyhomematic.devicetypes.misc import HMEvent
 from pyhomematic.devicetypes.helper import (
     HelperWorking, HelperActorState, HelperActorLevel, HelperActorBlindTilt, HelperActionOnTime,
-    HelperActionPress, HelperEventRemote, HelperWired)
+    HelperActionPress, HelperEventRemote, HelperWired, HelperRssiPeer)
 
 LOG = logging.getLogger(__name__)
 
@@ -34,7 +34,7 @@ class GenericBlind(HMActor, HelperActorLevel):
         self.actionNodeData("STOP", True, channel)
 
 
-class Blind(GenericBlind, HelperWorking):
+class Blind(GenericBlind, HelperWorking, HelperRssiPeer):
     """
     Blind switch that raises and lowers roller shutters or window blinds.
     """
@@ -174,7 +174,7 @@ class Rain(GenericSwitch, HelperWorking):
         return [2]
 
 
-class Switch(GenericSwitch, HelperWorking):
+class Switch(GenericSwitch, HelperWorking, HelperRssiPeer):
     """
     Switch turning plugged in device on or off.
     """
@@ -268,7 +268,7 @@ class HMWIOSwitch(GenericSwitch, HelperWired):
         return self._doc
 
 
-class RFSiren(GenericSwitch, HelperWorking):
+class RFSiren(GenericSwitch, HelperWorking, HelperRssiPeer):
     """
     HM-Sec-Sir-WM Siren
     """

--- a/pyhomematic/devicetypes/actors.py
+++ b/pyhomematic/devicetypes/actors.py
@@ -286,7 +286,7 @@ class RFSiren(GenericSwitch, HelperWorking, HelperRssiPeer):
         return [1, 2, 3]
 
 
-class KeyMatic(HMActor, HelperActorState):
+class KeyMatic(HMActor, HelperActorState, HelperRssiPeer):
     """
     Lock, Unlock or Open KeyMatic.
     """

--- a/pyhomematic/devicetypes/generic.py
+++ b/pyhomematic/devicetypes/generic.py
@@ -59,9 +59,6 @@ class HMGeneric():
             % (self._ADDRESS, interface_id, key, value))
         if key == PARAM_UNREACH:
             self._unreach = value
-        if not self._eventcallbacks:
-            LOG.debug("HMGeneric.event: No callbacks registered for event %s (%s)", key, str(self))
-
         for callback in self._eventcallbacks:
             LOG.debug("HMDevice.event: Using callback %s " % str(callback))
             callback(self._ADDRESS, interface_id, key, value)
@@ -216,7 +213,7 @@ class HMDevice(HMGeneric):
         # - 0...n / getValue from channel (fix)
         self._SENSORNODE = {}
         self._BINARYNODE = {}
-        self._ATTRIBUTENODE = {"RSSI_PEER": [0]}
+        self._ATTRIBUTENODE = {}
         self._WRITENODE = {}
         self._EVENTNODE = {}
         self._ACTIONNODE = {}
@@ -337,7 +334,13 @@ class HMDevice(HMGeneric):
         return False
 
     def get_rssi(self, channel=0):
-        return self.getAttributeData("RSSI_PEER", channel)
+        """
+        This is a stub method which is implemented by the helpers
+        HelperRssiPeer/HelperRssiDevice in order to provide a suitable
+        implementation for the device.
+        """
+        #pylint: disable=unused-argument
+        return 0
 
     @property
     def ELEMENT(self):
@@ -355,14 +358,9 @@ class HMDevice(HMGeneric):
         Signature for callback-functions: foo(address, interface_id, key, value)
         """
         if hasattr(callback, '__call__'):
-            LOG.debug(
-                "Adding callback '%s' for %s:%s (%s)",
-                str(callback), self._name, channel, str(self)
-            )
-
             if channel == 0:
                 self._eventcallbacks.append(callback)
-            if not bequeath and channel in self._hmchannels:
+            elif not bequeath and channel > 0 and channel in self._hmchannels:
                 self._hmchannels[channel]._eventcallbacks.append(callback)
             if bequeath:
                 for channel, device in self._hmchannels.items():

--- a/pyhomematic/devicetypes/generic.py
+++ b/pyhomematic/devicetypes/generic.py
@@ -213,7 +213,7 @@ class HMDevice(HMGeneric):
         # - 0...n / getValue from channel (fix)
         self._SENSORNODE = {}
         self._BINARYNODE = {}
-        self._ATTRIBUTENODE = {"RSSI_DEVICE": [0]}
+        self._ATTRIBUTENODE = {"RSSI_PEER": [0]}
         self._WRITENODE = {}
         self._EVENTNODE = {}
         self._ACTIONNODE = {}
@@ -334,7 +334,7 @@ class HMDevice(HMGeneric):
         return False
 
     def get_rssi(self, channel=0):
-        return self.getAttributeData("RSSI_DEVICE", channel)
+        return self.getAttributeData("RSSI_PEER", channel)
 
     @property
     def ELEMENT(self):

--- a/pyhomematic/devicetypes/generic.py
+++ b/pyhomematic/devicetypes/generic.py
@@ -59,6 +59,9 @@ class HMGeneric():
             % (self._ADDRESS, interface_id, key, value))
         if key == PARAM_UNREACH:
             self._unreach = value
+        if not self._eventcallbacks:
+            LOG.debug("HMGeneric.event: No callbacks registered for event %s (%s)", key, str(self))
+
         for callback in self._eventcallbacks:
             LOG.debug("HMDevice.event: Using callback %s " % str(callback))
             callback(self._ADDRESS, interface_id, key, value)
@@ -352,9 +355,14 @@ class HMDevice(HMGeneric):
         Signature for callback-functions: foo(address, interface_id, key, value)
         """
         if hasattr(callback, '__call__'):
+            LOG.debug(
+                "Adding callback '%s' for %s:%s (%s)",
+                str(callback), self._name, channel, str(self)
+            )
+
             if channel == 0:
                 self._eventcallbacks.append(callback)
-            elif not bequeath and channel > 0 and channel in self._hmchannels:
+            if not bequeath and channel in self._hmchannels:
                 self._hmchannels[channel]._eventcallbacks.append(callback)
             if bequeath:
                 for channel, device in self._hmchannels.items():

--- a/pyhomematic/devicetypes/helper.py
+++ b/pyhomematic/devicetypes/helper.py
@@ -238,8 +238,8 @@ class HelperEventRemote(HMDevice):
                                "PRESS_LONG_RELEASE": self.ELEMENT})
 
 class HelperWired(HMDevice):
-    """Remove the RSSI_DEVICE attribute"""
+    """Remove the RSSI_PEER attribute"""
     def __init__(self, device_description, proxy, resolveparamsets=False):
         super().__init__(device_description, proxy, resolveparamsets)
 
-        self.ATTRIBUTENODE.pop("RSSI_DEVICE", None)
+        self.ATTRIBUTENODE.pop("RSSI_PEER", None)

--- a/pyhomematic/devicetypes/helper.py
+++ b/pyhomematic/devicetypes/helper.py
@@ -238,8 +238,28 @@ class HelperEventRemote(HMDevice):
                                "PRESS_LONG_RELEASE": self.ELEMENT})
 
 class HelperWired(HMDevice):
-    """Remove the RSSI_PEER attribute"""
+    """Remove the RSSI-related attributes"""
     def __init__(self, device_description, proxy, resolveparamsets=False):
         super().__init__(device_description, proxy, resolveparamsets)
-
         self.ATTRIBUTENODE.pop("RSSI_PEER", None)
+        self.ATTRIBUTENODE.pop("RSSI_DEVICE", None)
+
+
+class HelperRssiDevice(HMDevice):
+    """Used for devices which report their RSSI value through RSSI_DEVICE"""
+    def __init__(self, device_description, proxy, resolveparamsets=False):
+        super().__init__(device_description, proxy, resolveparamsets)
+        self.ATTRIBUTENODE["RSSI_DEVICE"] = [0]
+
+    def get_rssi(self, channel=0):
+        return self.getAttributeData("RSSI_DEVICE", channel)
+
+
+class HelperRssiPeer(HMDevice):
+    """Used for devices which report their RSSI value through RSSI_PEER"""
+    def __init__(self, device_description, proxy, resolveparamsets=False):
+        super().__init__(device_description, proxy, resolveparamsets)
+        self.ATTRIBUTENODE["RSSI_PEER"] = [0]
+
+    def get_rssi(self, channel=0):
+        return self.getAttributeData("RSSI_PEER", channel)

--- a/pyhomematic/devicetypes/misc.py
+++ b/pyhomematic/devicetypes/misc.py
@@ -1,6 +1,6 @@
 import logging
 from pyhomematic.devicetypes.generic import HMDevice
-from pyhomematic.devicetypes.helper import HelperActionPress, HelperEventRemote, HelperEventPress
+from pyhomematic.devicetypes.helper import HelperActionPress, HelperEventRemote, HelperEventPress, HelperRssiPeer
 
 LOG = logging.getLogger(__name__)
 
@@ -21,7 +21,7 @@ class RemoteVirtual(HMCCU, HelperEventRemote, HelperActionPress):
         return [c for c in range(1, 51)]
 
 
-class Remote(HMEvent, HelperEventRemote, HelperActionPress):
+class Remote(HMEvent, HelperEventRemote, HelperActionPress, HelperRssiPeer):
     """Remote handle buttons."""
 
     @property

--- a/pyhomematic/devicetypes/misc.py
+++ b/pyhomematic/devicetypes/misc.py
@@ -38,7 +38,7 @@ class Remote(HMEvent, HelperEventRemote, HelperActionPress):
             return [1, 2, 3, 4]
         if "HM-PBI-4-FM" in self.TYPE or "ZEL STG RM FST UP4" in self.TYPE or "263 145" in self.TYPE or "HM-PBI-X" in self.TYPE:
             return [1, 2, 3, 4]
-        if "Sec4" in self.TYPE or "Key4" in self.TYPE:
+        if "Sec4" in self.TYPE or "Key4" in self.TYPE or "KRCA" in self.TYPE:
             return [1, 2, 3, 4]
         if "PB-6" in self.TYPE or "WRC6" in self.TYPE:
             return [1, 2, 3, 4, 5, 6]
@@ -122,6 +122,7 @@ DEVICETYPES = {
     "HMIP-WRC2": Remote,
     "HmIP-WRC2": Remote,
     "HmIP-WRC6": Remote,
+    "HmIP-KRCA": Remote,
     "HM-SwI-3-FM": RemotePress,
     "ZEL STG RM FSS UP3": RemotePress,
     "263 144": RemotePress,

--- a/pyhomematic/devicetypes/sensors.py
+++ b/pyhomematic/devicetypes/sensors.py
@@ -5,7 +5,7 @@ from pyhomematic.devicetypes.helper import (HelperLowBat, HelperSabotage,
                                             HelperLowBatIP, HelperSabotageIP,
                                             HelperBinaryState,
                                             HelperSensorState,
-                                            HelperWired, HelperEventRemote)
+                                            HelperWired, HelperEventRemote, HelperRssiPeer, HelperRssiDevice)
 
 LOG = logging.getLogger(__name__)
 
@@ -35,7 +35,7 @@ class IPShutterContact(HMBinarySensor, HelperBinaryState, HelperLowBat):
         return [1]
 
 
-class ShutterContact(IPShutterContact, HelperSabotage):
+class ShutterContact(IPShutterContact, HelperSabotage, HelperRssiPeer):
     """Door / Window contact that emits its open/closed state."""
     pass
 
@@ -60,7 +60,7 @@ class TiltSensor(HMBinarySensor, HelperBinaryState, HelperLowBat):
         return not self.get_state(channel)
 
 
-class RotaryHandleSensor(HMSensor, HelperSensorState, HelperLowBat, HelperSabotage):
+class RotaryHandleSensor(HMSensor, HelperSensorState, HelperLowBat, HelperSabotage, HelperRssiPeer):
     """Window handle contact."""
     def is_open(self, channel=None):
         """ Returns True if the handle is set to open. """
@@ -105,7 +105,7 @@ class CO2Sensor(HMSensor, HelperSensorState):
         return self.get_state(channel) == 2
 
 
-class WaterSensor(HMSensor, HelperSensorState, HelperLowBat):
+class WaterSensor(HMSensor, HelperSensorState, HelperLowBat, HelperRssiPeer):
     """Watter detect sensor."""
 
     def is_dry(self, channel=None):
@@ -121,7 +121,7 @@ class WaterSensor(HMSensor, HelperSensorState, HelperLowBat):
         return self.get_state(channel) == 2
 
 
-class PowermeterGas(HMSensor):
+class PowermeterGas(HMSensor, HelperRssiPeer):
     """Powermeter for Gas and energy."""
 
     def __init__(self, device_description, proxy, resolveparamsets=False):
@@ -167,7 +167,7 @@ class SmokeV2(Smoke, HelperLowBat):
                                    "ERROR_SMOKE_CHAMBER": self.ELEMENT})
 
 
-class IPSmoke(HMSensor):
+class IPSmoke(HMSensor, HelperRssiDevice):
     """HomeMatic IP Smoke sensor"""
 
     def __init__(self, device_description, proxy, resolveparamsets=False):

--- a/pyhomematic/devicetypes/sensors.py
+++ b/pyhomematic/devicetypes/sensors.py
@@ -535,7 +535,7 @@ class IPPassageSensor(HMSensor, HMBinarySensor, HelperEventRemote, HelperLowBatI
         self.BINARYNODE.update({"PASSAGE_COUNTER_OVERFLOW": self.ELEMENT,
                                 "LAST_PASSAGE_DIRECTION": [2],
                                 "CURRENT_PASSAGE_DIRECTION": [2]})
-        self.ATTRIBUTENODE.update({"RSSI_DEVICE": [0]})
+        self.ATTRIBUTENODE.update({"RSSI_PEER": [0]})
 
     @property
     def ELEMENT(self):

--- a/pyhomematic/devicetypes/sensors.py
+++ b/pyhomematic/devicetypes/sensors.py
@@ -523,6 +523,97 @@ class WeatherSensor(HMSensor, HMBinarySensor):
         """ Return True if motion is detected """
         return bool(self.getBinaryData("RAINING", channel))
 
+class IPWeatherSensorPlus(HMSensor, HMBinarySensor):
+    """HomeMatic IP Weather sensor Plus."""
+
+    def __init__(self, device_description, proxy, resolveparamsets=False):
+        super().__init__(device_description, proxy, resolveparamsets)
+
+        # init metadata
+        self.SENSORNODE.update({"ACTUAL_TEMPERATURE": [1],
+                                "HUMIDITY": [1],
+                                "RAIN_COUNTER": [1],
+                                "WIND_SPEED": [1],
+                                "SUNSHINEDURATION": [1],
+                                "ILLUMINATION": [1]})
+        self.BINARYNODE.update({"RAINING": [1]})
+        self.ATTRIBUTENODE.update({"LOW_BAT": [0],
+                                   "ERROR_CODE": [0],
+                                   "OPERATING_VOLTAGE": [0],
+                                   "TEMPERATURE_OUT_OF_RANGE": [0]})
+
+    def get_temperature(self, channel=None):
+        return float(self.getSensorData("ACTUAL_TEMPERATURE", channel))
+
+    def get_humidity(self, channel=None):
+        return int(self.getSensorData("HUMIDITY", channel))
+
+    def get_rain_counter(self, channel=None):
+        return float(self.getSensorData("RAIN_COUNTER", channel))
+
+    def get_wind_speed(self, channel=None):
+        return float(self.getSensorData("WIND_SPEED", channel))
+
+    def get_sunshineduration(self, channel=None):
+        return int(self.getSensorData("SUNSHINEDURATION", channel))
+
+    def get_brightness(self, channel=None):
+        return int(self.getSensorData("ILLUMINATION", channel))
+
+    def get_operating_voltage(self, channel=None):
+        return float(self.getAttributeData("OPERATING_VOLTAGE", channel))
+
+    def is_raining(self, channel=None):
+        return bool(self.getBinaryData("RAINING", channel))
+
+    def is_low_batt(self, channel=None):
+        return bool(self.getAttributeData("LOW_BAT", channel))
+
+    def is_temperature_out_of_range(self, channel=None):
+        return bool(self.getAttributeData("TEMPERATURE_OUT_OF_RANGE", channel))
+
+
+class IPWeatherSensorBasic(HMSensor, HMBinarySensor):
+    """HomeMatic IP Weather sensor Basic."""
+
+    def __init__(self, device_description, proxy, resolveparamsets=False):
+        super().__init__(device_description, proxy, resolveparamsets)
+
+        # init metadata
+        self.SENSORNODE.update({"ACTUAL_TEMPERATURE": [1],
+                                "HUMIDITY": [1],
+                                "WIND_SPEED": [1],
+                                "SUNSHINEDURATION": [1],
+                                "ILLUMINATION": [1]})
+        self.ATTRIBUTENODE.update({"LOW_BAT": [0],
+                                   "ERROR_CODE": [0],
+                                   "OPERATING_VOLTAGE": [0],
+                                   "TEMPERATURE_OUT_OF_RANGE": [0]})
+
+    def get_temperature(self, channel=None):
+        return float(self.getSensorData("ACTUAL_TEMPERATURE", channel))
+
+    def get_humidity(self, channel=None):
+        return int(self.getSensorData("HUMIDITY", channel))
+
+    def get_wind_speed(self, channel=None):
+        return float(self.getSensorData("WIND_SPEED", channel))
+
+    def get_sunshineduration(self, channel=None):
+        return int(self.getSensorData("SUNSHINEDURATION", channel))
+
+    def get_brightness(self, channel=None):
+        return int(self.getSensorData("ILLUMINATION", channel))
+
+    def get_operating_voltage(self, channel=None):
+        return float(self.getAttributeData("OPERATING_VOLTAGE", channel))
+
+    def is_low_batt(self, channel=None):
+        return bool(self.getAttributeData("LOW_BAT", channel))
+
+    def is_temperature_out_of_range(self, channel=None):
+        return bool(self.getAttributeData("TEMPERATURE_OUT_OF_RANGE", channel))
+
 
 class IPPassageSensor(HMSensor, HMBinarySensor, HelperEventRemote, HelperLowBatIP):
     """HomeMatic IP Passage Sensor. #2 = right to left, #3 = left to right"""
@@ -680,6 +771,8 @@ DEVICETYPES = {
     "KS550Tech": WeatherSensor,
     "KS550LC": WeatherSensor,
     "HmIP-SWO-PR": IPWeatherSensor,
+    "HmIP-SWO-PL": IPWeatherSensorPlus,
+    "HmIP-SWO-B": IPWeatherSensorBasic,
     "WS550": WeatherStation,
     "WS888": WeatherStation,
     "WS550Tech": WeatherStation,

--- a/pyhomematic/devicetypes/thermostats.py
+++ b/pyhomematic/devicetypes/thermostats.py
@@ -301,6 +301,37 @@ class IPThermostatWall(HMThermostat, HelperLowBatIP):
         """ Turn off Thermostat. """
         self.writeNodeData("SET_POINT_TEMPERATURE", self.OFF_VALUE)
 
+class IPThermostatWall230V(HMThermostat):
+    """
+    HmIP-BWTH
+    ClimateControl-Wall Thermostat that measures temperature and allows to set a target temperature or use some automatic mode.
+    """
+    def __init__(self, device_description, proxy, resolveparamsets=False):
+        super().__init__(device_description, proxy, resolveparamsets)
+
+        # init metadata
+        self.SENSORNODE.update({"ACTUAL_TEMPERATURE": [1],
+                                "HUMIDITY": [1]})
+        self.WRITENODE.update({"SET_POINT_TEMPERATURE": [1]})
+        self.ACTIONNODE.update({"BOOST_MODE": [1]})
+        self.ATTRIBUTENODE.update({"SET_POINT_MODE": [1]})
+
+    def get_set_temperature(self):
+        """ Returns the current target temperature. """
+        return self.getWriteData("SET_POINT_TEMPERATURE")
+
+    def set_temperature(self, target_temperature):
+        """ Set the target temperature. """
+        try:
+            target_temperature = float(target_temperature)
+        except Exception as err:
+            LOG.debug("Thermostat.set_temperature: Exception %s" % (err,))
+            return False
+        self.writeNodeData("SET_POINT_TEMPERATURE", target_temperature)
+
+    def turnoff(self):
+        """ Turn off Thermostat. """
+        self.writeNodeData("SET_POINT_TEMPERATURE", self.OFF_VALUE)
 
 DEVICETYPES = {
     "HM-CC-VG-1": ThermostatGroup,
@@ -324,6 +355,6 @@ DEVICETYPES = {
     "HmIP-WTH-2": IPThermostatWall,
     "HMIP-WTH": IPThermostatWall,
     "HmIP-WTH": IPThermostatWall,
-    "HmIP-BWTH": IPThermostatWall,
+    "HmIP-BWTH": IPThermostatWall230V,
     "HmIP-HEATING": IPThermostat,
 }

--- a/pyhomematic/devicetypes/thermostats.py
+++ b/pyhomematic/devicetypes/thermostats.py
@@ -1,7 +1,7 @@
 import logging
 from pyhomematic.devicetypes.generic import HMDevice
 from pyhomematic.devicetypes.sensors import AreaThermostat
-from pyhomematic.devicetypes.helper import HelperValveState, HelperBatteryState, HelperLowBat, HelperLowBatIP
+from pyhomematic.devicetypes.helper import HelperValveState, HelperBatteryState, HelperLowBat, HelperLowBatIP, HelperRssiPeer
 
 LOG = logging.getLogger(__name__)
 
@@ -123,7 +123,7 @@ class ThermostatGroup(HMThermostat):
                                    "CONTROL_MODE": [1]})
 
 
-class Thermostat(HMThermostat, HelperBatteryState, HelperValveState):
+class Thermostat(HMThermostat, HelperBatteryState, HelperValveState, HelperRssiPeer):
     """
     HM-CC-RT-DN, HM-CC-RT-DN-BoM
     ClimateControl-Radiator Thermostat that measures temperature and allows to set a target temperature or use some automatic mode.
@@ -144,7 +144,7 @@ class Thermostat(HMThermostat, HelperBatteryState, HelperValveState):
                                    "CONTROL_MODE": [4]})
 
 
-class ThermostatWall(HMThermostat, AreaThermostat, HelperBatteryState):
+class ThermostatWall(HMThermostat, AreaThermostat, HelperBatteryState, HelperRssiPeer):
     """
     HM-TC-IT-WM-W-EU
     ClimateControl-Wall Thermostat that measures temperature and allows to set a target temperature or use some automatic mode.

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ def readme():
 
 PACKAGE_NAME = 'pyhomematic'
 HERE = os.path.abspath(os.path.dirname(__file__))
-VERSION = '0.1.46'
+VERSION = '0.1.47'
 
 PACKAGES = find_packages(exclude=['tests', 'tests.*', 'dist', 'build'])
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ def readme():
 
 PACKAGE_NAME = 'pyhomematic'
 HERE = os.path.abspath(os.path.dirname(__file__))
-VERSION = '0.1.48'
+VERSION = '0.1.49'
 
 PACKAGES = find_packages(exclude=['tests', 'tests.*', 'dist', 'build'])
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ def readme():
 
 PACKAGE_NAME = 'pyhomematic'
 HERE = os.path.abspath(os.path.dirname(__file__))
-VERSION = '0.1.47'
+VERSION = '0.1.48'
 
 PACKAGES = find_packages(exclude=['tests', 'tests.*', 'dist', 'build'])
 

--- a/tests/test_pyhomematic.py
+++ b/tests/test_pyhomematic.py
@@ -8,6 +8,7 @@ import json
 from pyhomematic import vccu
 from pyhomematic import HMConnection
 from pyhomematic import devicetypes
+from pyhomematic.devicetypes.helper import HelperRssiDevice, HelperRssiPeer
 
 logging.basicConfig(level=logging.INFO)
 LOG = logging.getLogger(__name__)
@@ -144,6 +145,28 @@ class Test_2_PyhomematicDevices(unittest.TestCase):
                     LOG.info("Unsupported device: %s" % deviceobject.TYPE)
                 else:
                     LOG.warning("Device class missing for: %s" % deviceobject.TYPE)
+
+
+class Test_3_HelperClassHierarchy(unittest.TestCase):
+    """
+    Some helper classes are mutally exclusive (such as HelperRssiPeer/HelperRssiDevice).
+
+    Since many device implementations inherit from other implementation classes we need
+    to be extra careful when plugging in such mutally excluse helpers somewhere in the
+    class hierarchy. This test case may be used for checking the currently available device
+    classes for such situations.
+    """
+    def setUp(self):
+        self.device_classes = set(devicetypes.SUPPORTED.values())
+
+    def test_rssi_helper(self):
+        for klass in self.device_classes:
+            both_rssi_helpers_used = issubclass(HelperRssiDevice, klass) and issubclass(HelperRssiPeer, klass)
+            self.assertFalse(
+                both_rssi_helpers_used, 
+                "The class %s inherits from both HelperRssiDevice and HelperRssiPeer, which is not supported." % klass
+            )
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
- Rework RSSI handling (fixes #164, fixes #121)
- Prevent failure of everything when single host is down (fixes #162)

Further notes:
In HASS we need to add `RSSI_DEVICE` to `HM_ATTRIBUTE_SUPPORT`.