### PR TITLE
Add valve level to IP Thermostat attributes

### DIFF
--- a/pyhomematic/devicetypes/thermostats.py
+++ b/pyhomematic/devicetypes/thermostats.py
@@ -231,7 +231,8 @@ class IPThermostat(HMThermostat, HelperLowBatIP, HelperValveState):
                                    "OPERATING_VOLTAGE": [0],
                                    "SET_POINT_MODE": [1],
                                    "BOOST_MODE": [1],
-                                   "VALVE_STATE": [1]})
+                                   "VALVE_STATE": [1],
+                                   "LEVEL": [1]})
 
     def get_set_temperature(self):
         """ Returns the current target temperature. """


### PR DESCRIPTION
The attributes of thermostats contains "VALVE_STATE" but not "LEVEL".
VALVE_STATE only shows if the adaptation was successful and once it is at 4, it will not change anymore.
LEVEL on the other hand returns the valve's degree of opening (a value between 0 and 1).
This can be useful to visualize temperature changes and number of valve openings.
A small Home Assistant PR will be opened once this PR is approved.