### PR TITLE
HmIP-MOD-TM

### DIFF
--- a/pyhomematic/devicetypes/actors.py
+++ b/pyhomematic/devicetypes/actors.py
@@ -420,27 +420,27 @@ class IPGarage(GenericSwitch, HMSensor):
         super().__init__(device_description, proxy, resolveparamsets)
 
         # init metadata
-        self.SENSORNODE.update({"DOOR_STATE": self.ELEMENT})
+        self.SENSORNODE.update({"DOOR_STATE": [1]})
 
     def move_up(self):
         """Opens the garage"""
-        return self.setValue("DOOR_COMMAND", 1)
+        return self.setValue("DOOR_COMMAND", 1, channel=1),
 
     def stop(self):
         """Stop motion"""
-        return self.setValue("DOOR_COMMAND", 2)
+        return self.setValue("DOOR_COMMAND", 2, channel=1)
 
     def move_down(self):
         """Close the garage"""
-        return self.setValue("DOOR_COMMAND", 3)
+        return self.setValue("DOOR_COMMAND", 3, channel=1)
 
     def vent(self):
         """Go to ventilation position"""
-        return self.setValue("DOOR_COMMAND", 4)
+        return self.setValue("DOOR_COMMAND", 4, channel=1)
 
     @property
     def ELEMENT(self):
-        return [1]
+        return [2]
 
 
 DEVICETYPES = {

--- a/pyhomematic/devicetypes/actors.py
+++ b/pyhomematic/devicetypes/actors.py
@@ -412,6 +412,37 @@ class IPKeySwitchPowermeter(IPSwitchPowermeter, HMEvent, HelperActionPress):
                                "PRESS_LONG": [1, 2]})
 
 
+class IPGarage(GenericSwitch, HMSensor):
+    """
+    HmIP-MOD-TM Garage actor
+    """
+    def __init__(self, device_description, proxy, resolveparamsets=False):
+        super().__init__(device_description, proxy, resolveparamsets)
+
+        # init metadata
+        self.SENSORNODE.update({"DOOR_STATE": [self.ELEMENT]})
+
+    def move_up(self):
+        """Opens the garage"""
+        return self.setValue("DOOR_COMMAND", 1)
+
+    def stop(self):
+        """Stop motion"""
+        return self.setValue("DOOR_COMMAND", 2)
+
+    def move_down(self):
+        """Close the garage"""
+        return self.setValue("DOOR_COMMAND", 3)
+
+    def vent(self):
+        """Go to ventilation position"""
+        return self.setValue("DOOR_COMMAND", 4)
+
+    @property
+    def ELEMENT(self):
+        return [1]
+
+
 DEVICETYPES = {
     "HM-LC-Bl1-SM": Blind,
     "HM-LC-Bl1-SM-2": Blind,
@@ -541,4 +572,5 @@ DEVICETYPES = {
     "HM-Sen-RD-O": Rain,
     "ST6-SH": EcoLogic,
     "HM-Sec-Sir-WM": RFSiren,
+    "HmIP-MOD-TM": IPGarage,
 }

--- a/pyhomematic/devicetypes/actors.py
+++ b/pyhomematic/devicetypes/actors.py
@@ -420,7 +420,7 @@ class IPGarage(GenericSwitch, HMSensor):
         super().__init__(device_description, proxy, resolveparamsets)
 
         # init metadata
-        self.SENSORNODE.update({"DOOR_STATE": [self.ELEMENT]})
+        self.SENSORNODE.update({"DOOR_STATE": self.ELEMENT})
 
     def move_up(self):
         """Opens the garage"""

--- a/pyhomematic/devicetypes/actors.py
+++ b/pyhomematic/devicetypes/actors.py
@@ -424,7 +424,7 @@ class IPGarage(GenericSwitch, HMSensor):
 
     def move_up(self):
         """Opens the garage"""
-        return self.setValue("DOOR_COMMAND", 1, channel=1),
+        return self.setValue("DOOR_COMMAND", 1, channel=1)
 
     def stop(self):
         """Stop motion"""


### PR DESCRIPTION
This pull request:
- fixes issue: #170 
- adds support for HomeMatic device: HmIP-MOD-TM
  - New class: `IPGarage`
  - Home Assistant [platform](https://github.com/home-assistant/home-assistant/blob/0da3e737651a150c17016f43b5f9144deff7ddd7/homeassistant/components/homematic/__init__.py#L65): `DISCOVER_SENSORS`, `DISCOVER_SWITCHES`

Controllable via automations like this:

```yaml
action:
  service: homematic.set_device_value
  data:
    address: 00112233
    channel: 1
    param: DOOR_COMMAND
    value: 1
```

The values:
- Open: 1
- Stop (while moving): 2
- Close : 3
- Vent-position: 4