### PR TITLE
0.1.52

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 Version 0.1.52 (2018-)
 - Added HmIP-MOD-TM (Issue #170) @danielperna84
+- Added HM-LC-RGBW-WM @chr1st1ank
 
 Version 0.1.51 (2018-10-14)
 - Added device_descriptions.json to distributed package to allow performing tests with vccu

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,5 @@
 Version 0.1.52 (2018-)
+- Added HmIP-MOD-TM (Issue #170) @danielperna84
 
 Version 0.1.51 (2018-10-14)
 - Added device_descriptions.json to distributed package to allow performing tests with vccu

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,5 @@
+Version 0.1.52 (2018-)
+
 Version 0.1.51 (2018-10-14)
 - Added device_descriptions.json to distributed package to allow performing tests with vccu
 - Add valve level to IP Thermostat attributes @hanzoh

--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@ Version 0.1.52 (2018-)
 - Added HM-LC-RGBW-WM @chr1st1ank
 - Added caching of parameters received by events @chr1st1ank
 - Added HmIP-PCBS (Issue #178) @danielperna84
+- Fix HM-CC-TC obsolete battery (Issue #183) @danielperna84
 
 Version 0.1.51 (2018-10-14)
 - Added device_descriptions.json to distributed package to allow performing tests with vccu

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,4 @@
-Version 0.1.52 (2018-)
+Version 0.1.52 (2018-11-15)
 - Added HmIP-MOD-TM (Issue #170) @danielperna84
 - Added HM-LC-RGBW-WM @chr1st1ank
 - Added caching of parameters received by events @chr1st1ank

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 Version 0.1.52 (2018-)
 - Added HmIP-MOD-TM (Issue #170) @danielperna84
 - Added HM-LC-RGBW-WM @chr1st1ank
+- Added caching of parameters received by events @chr1st1ank
 
 Version 0.1.51 (2018-10-14)
 - Added device_descriptions.json to distributed package to allow performing tests with vccu

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@ Version 0.1.52 (2018-)
 - Added HmIP-MOD-TM (Issue #170) @danielperna84
 - Added HM-LC-RGBW-WM @chr1st1ank
 - Added caching of parameters received by events @chr1st1ank
+- Added HmIP-PCBS (Issue #178) @danielperna84
 
 Version 0.1.51 (2018-10-14)
 - Added device_descriptions.json to distributed package to allow performing tests with vccu

--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@ Version 0.1.52 (2018-)
 - Added caching of parameters received by events @chr1st1ank
 - Added HmIP-PCBS (Issue #178) @danielperna84
 - Fix HM-CC-TC obsolete battery (Issue #183) @danielperna84
+- Added HmIP-PDT (Issue #181) @danielperna84
 
 Version 0.1.51 (2018-10-14)
 - Added device_descriptions.json to distributed package to allow performing tests with vccu

--- a/pyhomematic/devicetypes/actors.py
+++ b/pyhomematic/devicetypes/actors.py
@@ -647,6 +647,7 @@ DEVICETYPES = {
     "HMW-LC-Dim1L-DR": KeyDimmer,
     "HMIP-PS": IPSwitch,
     "HmIP-PS": IPSwitch,
+    "HmIP-PCBS": IPSwitch,
     "HMIP-PSM": IPSwitchPowermeter,
     "HmIP-PSM": IPSwitchPowermeter,
     "HmIP-PSM-CH": IPSwitchPowermeter,

--- a/pyhomematic/devicetypes/actors.py
+++ b/pyhomematic/devicetypes/actors.py
@@ -124,9 +124,18 @@ class KeyDimmer(GenericDimmer, HelperWorking, HelperActionPress):
         return [3]
 
 
-class IPKeyDimmer(GenericDimmer, HelperWorking, HelperActionPress):
+class IPDimmer(GenericDimmer):
     """
     IP Dimmer switch that controls level of light brightness.
+    """
+    @property
+    def ELEMENT(self):
+        return [3]
+
+
+class IPKeyDimmer(GenericDimmer, HelperWorking, HelperActionPress):
+    """
+    IP Dimmer with buttons switch that controls level of light brightness.
     """
     def __init__(self, device_description, proxy, resolveparamsets=False):
         super().__init__(device_description, proxy, resolveparamsets)
@@ -656,6 +665,7 @@ DEVICETYPES = {
     "HmIP-BSM": IPKeySwitchPowermeter,
     "HMIP-BDT": IPKeyDimmer,
     "HmIP-BDT": IPKeyDimmer,
+    "HmIP-PDT": IPDimmer,
     "HM-Sec-Key": KeyMatic,
     "HM-Sec-Key-S": KeyMatic,
     "HM-Sec-Key-O": KeyMatic,

--- a/pyhomematic/devicetypes/actors.py
+++ b/pyhomematic/devicetypes/actors.py
@@ -412,6 +412,37 @@ class IPKeySwitchPowermeter(IPSwitchPowermeter, HMEvent, HelperActionPress):
                                "PRESS_LONG": [1, 2]})
 
 
+class IPGarage(GenericSwitch, HMSensor):
+    """
+    HmIP-MOD-TM Garage actor
+    """
+    def __init__(self, device_description, proxy, resolveparamsets=False):
+        super().__init__(device_description, proxy, resolveparamsets)
+
+        # init metadata
+        self.SENSORNODE.update({"DOOR_STATE": [1]})
+
+    def move_up(self):
+        """Opens the garage"""
+        return self.setValue("DOOR_COMMAND", 1, channel=1)
+
+    def stop(self):
+        """Stop motion"""
+        return self.setValue("DOOR_COMMAND", 2, channel=1)
+
+    def move_down(self):
+        """Close the garage"""
+        return self.setValue("DOOR_COMMAND", 3, channel=1)
+
+    def vent(self):
+        """Go to ventilation position"""
+        return self.setValue("DOOR_COMMAND", 4, channel=1)
+
+    @property
+    def ELEMENT(self):
+        return [2]
+
+
 DEVICETYPES = {
     "HM-LC-Bl1-SM": Blind,
     "HM-LC-Bl1-SM-2": Blind,
@@ -541,4 +572,5 @@ DEVICETYPES = {
     "HM-Sen-RD-O": Rain,
     "ST6-SH": EcoLogic,
     "HM-Sec-Sir-WM": RFSiren,
+    "HmIP-MOD-TM": IPGarage,
 }

--- a/pyhomematic/devicetypes/generic.py
+++ b/pyhomematic/devicetypes/generic.py
@@ -27,8 +27,9 @@ class HMGeneric():
         self._proxy = proxy
         self._paramsets = {}
         self._eventcallbacks = []
-        self._unreach = None
         self._name = None
+        self._VALUES = {}   # Dictionary to cache values. They are updated in the event() function.
+        self._VALUES[PARAM_UNREACH] = None
 
     @property
     def ADDRESS(self):
@@ -57,8 +58,9 @@ class HMGeneric():
         LOG.info(
             "HMGeneric.event: address=%s, interface_id=%s, key=%s, value=%s"
             % (self._ADDRESS, interface_id, key, value))
-        if key == PARAM_UNREACH:
-            self._unreach = value
+
+        self._VALUES[key] = value   # Cache the value
+
         for callback in self._eventcallbacks:
             LOG.debug("HMDevice.event: Using callback %s " % str(callback))
             callback(self._ADDRESS, interface_id, key, value)
@@ -86,7 +88,7 @@ class HMGeneric():
                         self._paramsets[paramset] = returnset
                         if self.PARAMSETS:
                             if self.PARAMSETS.get(PARAMSET_VALUES):
-                                self._unreach = self.PARAMSETS.get(PARAMSET_VALUES).get(PARAM_UNREACH)
+                                self._VALUES[PARAM_UNREACH] = self.PARAMSETS.get(PARAMSET_VALUES).get(PARAM_UNREACH)
                         return True
             return False
         except Exception as err:
@@ -154,6 +156,16 @@ class HMChannel(HMGeneric):
         if resolveparamsets:
             self.updateParamsets()
 
+    def getCachedOrUpdatedValue(self, key):
+        """ Gets the device's value with the given key.
+
+        If the key is not found in the cache, the value is queried from the host.
+        """
+        try:
+            return self._VALUES[key]
+        except KeyError:
+            return self.getValue(key)
+
     @property
     def PARENT(self):
         return self._PARENT
@@ -161,9 +173,7 @@ class HMChannel(HMGeneric):
     @property
     def UNREACH(self):
         """ Returns true if children is not reachable """
-        if self._unreach:
-            return True
-        return False
+        return bool(self._VALUES.get(PARAM_UNREACH, False))
 
     def setEventCallback(self, callback):
         """
@@ -193,6 +203,7 @@ class HMChannel(HMGeneric):
         LOG.debug("HMGeneric.getValue: address = '%s', key = '%s'" % (self._ADDRESS, key))
         try:
             returnvalue = self._proxy.getValue(self._ADDRESS, key)
+            self._VALUES[key] = returnvalue
             return returnvalue
         except Exception as err:
             LOG.error("HMGeneric.getValue: %s on %s Exception: %s", key,
@@ -240,10 +251,25 @@ class HMDevice(HMGeneric):
         self._UPDATABLE = device_description.get('UPDATABLE')
         self._PARENT_TYPE = None
 
+    def getCachedOrUpdatedValue(self, key, channel=None):
+        """ Gets the channel's value with the given key.
+
+        If the key is not found in the cache, the value is queried from the host.
+        If 'channel' is given, the respective channel's value is returned.
+        """
+        if channel:
+            return self._hmchannels[channel].getCachedOrUpdatedValue(key)
+
+        try:
+            return self._VALUES[key]
+        except KeyError:
+            value = self._VALUES[key] = self.getValue(key)
+            return value
+
     @property
     def UNREACH(self):
         """ Returns true if the device or any children is not reachable """
-        if self._unreach:
+        if self._VALUES.get(PARAM_UNREACH, False):
             return True
         else:
             for device in self._hmchannels.values():

--- a/pyhomematic/devicetypes/json/device_details.json
+++ b/pyhomematic/devicetypes/json/device_details.json
@@ -61,7 +61,7 @@
     "HM-RC-4-3": {},
     "HM-Sec-SD-2-Team": {"supported": false},
     "HmIP-FSM16": {"supported": false},
-    "HM-LC-RGBW-WM": {"supported": false},
+    "HM-LC-RGBW-WM": {},
     "HMIP-WTH": {},
     "HmIP-BSM": {},
     "HmIP-SAM": {},

--- a/pyhomematic/devicetypes/thermostats.py
+++ b/pyhomematic/devicetypes/thermostats.py
@@ -354,6 +354,7 @@ DEVICETYPES = {
     "HmIP-STHD": IPThermostatWall,
     "HmIP-STH": IPThermostatWall,
     "HmIP-WTH-2": IPThermostatWall,
+    "HMIP-WTH-2": IPThermostatWall,
     "HMIP-WTH": IPThermostatWall,
     "HmIP-WTH": IPThermostatWall,
     "HmIP-BWTH": IPThermostatWall230V,

--- a/pyhomematic/devicetypes/thermostats.py
+++ b/pyhomematic/devicetypes/thermostats.py
@@ -164,7 +164,7 @@ class ThermostatWall(HMThermostat, AreaThermostat, HelperBatteryState, HelperRss
         self.ATTRIBUTENODE.update({"CONTROL_MODE": [2], "BATTERY_STATE": [2]})
 
 
-class ThermostatWall2(HMThermostat, AreaThermostat, HelperLowBat):
+class ThermostatWall2(HMThermostat, AreaThermostat):
     """
     HM-CC-TC
     ClimateControl-Wall Thermostat that measures temperature and allows to set a target temperature or use some automatic mode.

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ def readme():
 
 PACKAGE_NAME = 'pyhomematic'
 HERE = os.path.abspath(os.path.dirname(__file__))
-VERSION = '0.1.51'
+VERSION = '0.1.52'
 
 PACKAGES = find_packages(exclude=['tests', 'tests.*', 'dist', 'build'])
 


### PR DESCRIPTION
This pull request:
- Removes battery and working helpers from HM-CC-TC
- fixes issue: #170, #178, #183, #181
- adds support for HomeMatic device: HmIP-PCBS
- adds support for HomeMatic device: HmIP-MOD-TM
  - New class: IPGarage
  - Home Assistant [platform](https://github.com/home-assistant/home-assistant/blob/0da3e737651a150c17016f43b5f9144deff7ddd7/homeassistant/components/homematic/__init__.py#L65): `DISCOVER_SWITCHES`, `DISCOVER_SENSORS`
- adds support for HomeMatic device: HM-LC-RGBW-WM
  - New class: ColorEffectLight
  - Home Assistant [platform](https://github.com/home-assistant/home-assistant/blob/0da3e737651a150c17016f43b5f9144deff7ddd7/homeassistant/components/homematic/__init__.py#L65): `DISCOVER_LIGHTS`
  - Changes in platform as posted in [this](https://gist.github.com/chr1st1ank/742997ea102f734d2a13db323fac3f15) gist
- adds support for HomeMatic device: HmIP-PDT
  - New class: IPDimmer
  - Home Assistant [platform](https://github.com/home-assistant/home-assistant/blob/0da3e737651a150c17016f43b5f9144deff7ddd7/homeassistant/components/homematic/__init__.py#L65): `DISCOVER_LIGHTS`
