### PR TITLE
Adding support for HmIP-eTRV-B to thermostats.py

### DIFF
--- a/pyhomematic/devicetypes/thermostats.py
+++ b/pyhomematic/devicetypes/thermostats.py
@@ -351,6 +351,7 @@ DEVICETYPES = {
     "HMIP-eTRV": IPThermostat,
     "HmIP-eTRV": IPThermostat,
     "HmIP-eTRV-2": IPThermostat,
+    "HmIP-eTRV-B": IPThermostat,
     "HmIP-STHD": IPThermostatWall,
     "HmIP-STH": IPThermostatWall,
     "HmIP-WTH-2": IPThermostatWall,


### PR DESCRIPTION
This is the basic thermostat included in HmIP-SK9 (https://www.homematic-ip.com/en/products/detail/starter-set-heating-easy-connect.html).

Please point your pull request at the __devel__ branch. Also provide some information about the changes.

This pull request:
- fixes issue: \<Link to issue>
- adds support for HomeMatic device: HmIP-eTRV-B
  - Home Assistant [platform](https://github.com/home-assistant/home-assistant/blob/0da3e737651a150c17016f43b5f9144deff7ddd7/homeassistant/components/homematic/__init__.py#L65): `DISCOVER_CLIMATE`
