### PR TITLE
0.1.53

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,10 +1,11 @@
-Version 0.1.53 (2018-)
+Version 0.1.53 (2018-12-05)
 - Changed loglevel for getValue to `warning` (Issue #153) @danielperna84
 - Channel for LOW_BAT always is 0 for HmIP devices (Issue #186) @danielperna84
 - Support hostnames for XML-RPC endpoints @danielperna84
 - Add support for HmIP-eTRV-B @SiwYv
 - Added support for HmIP-FDT @DieterChmod
 - Added support for HB-UW-Sen-THPL-O and HB-UW-Sen-THPL-I @rgriebl
+- Add support for SSL and authentication with CCU3 @danielperna84
 
 Version 0.1.52 (2018-11-15)
 - Added HmIP-MOD-TM (Issue #170) @danielperna84

--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@ Version 0.1.52 (2018-)
 - Added HM-LC-RGBW-WM @chr1st1ank
 - Added caching of parameters received by events @chr1st1ank
 - Added HmIP-PCBS (Issue #178) @danielperna84
+- Fix HM-CC-TC obsolete battery (Issue #183) @danielperna84
 
 Version 0.1.51 (2018-10-14)
 - Added device_descriptions.json to distributed package to allow performing tests with vccu

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+Version 0.1.53 ()
+- Changed loglevel for getValue to `warning` (Issue #153) @danielperna84
+
 Version 0.1.52 (2018-11-15)
 - Added HmIP-MOD-TM (Issue #170) @danielperna84
 - Added HM-LC-RGBW-WM @chr1st1ank

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,4 @@
-Version 0.1.52 (2018-)
+Version 0.1.52 (2018-11-15)
 - Added HmIP-MOD-TM (Issue #170) @danielperna84
 - Added HM-LC-RGBW-WM @chr1st1ank
 - Added caching of parameters received by events @chr1st1ank

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,8 @@
-Version 0.1.53 ()
+Version 0.1.53 (2018-)
 - Changed loglevel for getValue to `warning` (Issue #153) @danielperna84
 - Channel for LOW_BAT always is 0 for HmIP devices (Issue #186) @danielperna84
 - Support hostnames for XML-RPC endpoints @danielperna84
+- Add support for HmIP-eTRV-B @SiwYv
 
 Version 0.1.52 (2018-11-15)
 - Added HmIP-MOD-TM (Issue #170) @danielperna84

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@ Version 0.1.52 (2018-)
 - Added HmIP-MOD-TM (Issue #170) @danielperna84
 - Added HM-LC-RGBW-WM @chr1st1ank
 - Added caching of parameters received by events @chr1st1ank
+- Added HmIP-PCBS (Issue #178) @danielperna84
 
 Version 0.1.51 (2018-10-14)
 - Added device_descriptions.json to distributed package to allow performing tests with vccu

--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,8 @@ Version 0.1.53 (2018-)
 - Channel for LOW_BAT always is 0 for HmIP devices (Issue #186) @danielperna84
 - Support hostnames for XML-RPC endpoints @danielperna84
 - Add support for HmIP-eTRV-B @SiwYv
+- Added support for HmIP-FDT @DieterChmod
+- Added support for HB-UW-Sen-THPL-O and HB-UW-Sen-THPL-I @rgriebl
 
 Version 0.1.52 (2018-11-15)
 - Added HmIP-MOD-TM (Issue #170) @danielperna84

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 Version 0.1.53 ()
 - Changed loglevel for getValue to `warning` (Issue #153) @danielperna84
 - Channel for LOW_BAT always is 0 for HmIP devices (Issue #186) @danielperna84
+- Support hostnames for XML-RPC endpoints @danielperna84
 
 Version 0.1.52 (2018-11-15)
 - Added HmIP-MOD-TM (Issue #170) @danielperna84

--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@ Version 0.1.52 (2018-)
 - Added caching of parameters received by events @chr1st1ank
 - Added HmIP-PCBS (Issue #178) @danielperna84
 - Fix HM-CC-TC obsolete battery (Issue #183) @danielperna84
+- Added HmIP-PDT (Issue #181) @danielperna84
 
 Version 0.1.51 (2018-10-14)
 - Added device_descriptions.json to distributed package to allow performing tests with vccu

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 Version 0.1.53 ()
 - Changed loglevel for getValue to `warning` (Issue #153) @danielperna84
+- Channel for LOW_BAT always is 0 for HmIP devices (Issue #186) @danielperna84
 
 Version 0.1.52 (2018-11-15)
 - Added HmIP-MOD-TM (Issue #170) @danielperna84

--- a/changelog.txt
+++ b/changelog.txt
@@ -6,6 +6,7 @@ Version 0.1.53 (2018-12-05)
 - Added support for HmIP-FDT @DieterChmod
 - Added support for HB-UW-Sen-THPL-O and HB-UW-Sen-THPL-I @rgriebl
 - Add support for SSL and authentication with CCU3 @danielperna84
+- Added support for HmIP-B1 @jberrenberg
 
 Version 0.1.52 (2018-11-15)
 - Added HmIP-MOD-TM (Issue #170) @danielperna84

--- a/pyhomematic/_hm.py
+++ b/pyhomematic/_hm.py
@@ -508,7 +508,7 @@ class ServerThread(threading.Thread):
         for remote, host in self.remotes.items():
             # Initialize XML-RPC
             try:
-                socket.inet_pton(socket.AF_INET, host['ip'])
+                socket.gethostbyname(host['ip'])
             except Exception as err:
                 LOG.warning("Skipping proxy: %s" % str(err))
                 continue

--- a/pyhomematic/_hm.py
+++ b/pyhomematic/_hm.py
@@ -2,6 +2,7 @@ import os
 import threading
 import json
 import urllib.request
+import urllib.parse
 import xml.etree.ElementTree as ET
 from xmlrpc.server import SimpleXMLRPCServer
 from xmlrpc.server import SimpleXMLRPCRequestHandler
@@ -401,8 +402,9 @@ class LockingServerProxy(xmlrpc.client.ServerProxy):
         self._callbackport = kwargs.pop("callbackport", None)
         self.lock = threading.Lock()
         xmlrpc.client.ServerProxy.__init__(self, *args, **kwargs)
-        self._remoteip, self._remoteport = self._ServerProxy__host.split(':')
-        self._remoteport = int(self._remoteport)
+        urlcomponents = urllib.parse.urlparse(args[0])
+        self._remoteip = urlcomponents.hostname
+        self._remoteport = urlcomponents.port
         LOG.debug("LockingServerProxy.__init__: Getting local ip")
         tmpsocket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         tmpsocket.connect((self._remoteip, self._remoteport))

--- a/pyhomematic/devicetypes/actors.py
+++ b/pyhomematic/devicetypes/actors.py
@@ -13,7 +13,6 @@ class HMActor(HMDevice):
     """
     Generic HM Actor Object
     """
-    pass
 
 
 class GenericBlind(HMActor, HelperActorLevel):

--- a/pyhomematic/devicetypes/actors.py
+++ b/pyhomematic/devicetypes/actors.py
@@ -647,6 +647,7 @@ DEVICETYPES = {
     "HMW-LC-Dim1L-DR": KeyDimmer,
     "HMIP-PS": IPSwitch,
     "HmIP-PS": IPSwitch,
+    "HmIP-PCBS": IPSwitch,
     "HMIP-PSM": IPSwitchPowermeter,
     "HmIP-PSM": IPSwitchPowermeter,
     "HmIP-PSM-CH": IPSwitchPowermeter,

--- a/pyhomematic/devicetypes/actors.py
+++ b/pyhomematic/devicetypes/actors.py
@@ -124,9 +124,18 @@ class KeyDimmer(GenericDimmer, HelperWorking, HelperActionPress):
         return [3]
 
 
-class IPKeyDimmer(GenericDimmer, HelperWorking, HelperActionPress):
+class IPDimmer(GenericDimmer):
     """
     IP Dimmer switch that controls level of light brightness.
+    """
+    @property
+    def ELEMENT(self):
+        return [3]
+
+
+class IPKeyDimmer(GenericDimmer, HelperWorking, HelperActionPress):
+    """
+    IP Dimmer with buttons switch that controls level of light brightness.
     """
     def __init__(self, device_description, proxy, resolveparamsets=False):
         super().__init__(device_description, proxy, resolveparamsets)
@@ -656,6 +665,7 @@ DEVICETYPES = {
     "HmIP-BSM": IPKeySwitchPowermeter,
     "HMIP-BDT": IPKeyDimmer,
     "HmIP-BDT": IPKeyDimmer,
+    "HmIP-PDT": IPDimmer,
     "HM-Sec-Key": KeyMatic,
     "HM-Sec-Key-S": KeyMatic,
     "HM-Sec-Key-O": KeyMatic,

--- a/pyhomematic/devicetypes/generic.py
+++ b/pyhomematic/devicetypes/generic.py
@@ -207,7 +207,7 @@ class HMChannel(HMGeneric):
             return returnvalue
         except Exception as err:
             LOG.warning("HMGeneric.getValue: %s on %s Exception: %s", key,
-                      self._ADDRESS, err)
+                        self._ADDRESS, err)
             return False
 
 

--- a/pyhomematic/devicetypes/generic.py
+++ b/pyhomematic/devicetypes/generic.py
@@ -206,7 +206,7 @@ class HMChannel(HMGeneric):
             self._VALUES[key] = returnvalue
             return returnvalue
         except Exception as err:
-            LOG.error("HMGeneric.getValue: %s on %s Exception: %s", key,
+            LOG.warning("HMGeneric.getValue: %s on %s Exception: %s", key,
                       self._ADDRESS, err)
             return False
 

--- a/pyhomematic/devicetypes/helper.py
+++ b/pyhomematic/devicetypes/helper.py
@@ -45,7 +45,7 @@ class HelperLowBatIP(HMDevice):
         super().__init__(device_description, proxy, resolveparamsets)
 
         # init metadata
-        self.ATTRIBUTENODE.update({"LOW_BAT": self.ELEMENT})
+        self.ATTRIBUTENODE.update({"LOW_BAT": [0]})
 
     def low_batt(self, channel=None):
         """ Returns if the battery is low. """

--- a/pyhomematic/devicetypes/sensors.py
+++ b/pyhomematic/devicetypes/sensors.py
@@ -37,7 +37,6 @@ class IPShutterContact(HMBinarySensor, HelperBinaryState, HelperLowBat):
 
 class ShutterContact(IPShutterContact, HelperSabotage, HelperRssiPeer):
     """Door / Window contact that emits its open/closed state."""
-    pass
 
 
 class MaxShutterContact(HMBinarySensor, HelperBinaryState, HelperLowBat):
@@ -282,7 +281,6 @@ class SmartwareMotion(HMBinarySensor, HMSensor):
 
 class MotionV2(Motion, HelperSabotage):
     """Motion detection version 2."""
-    pass
 
 
 class MotionIP(HMBinarySensor, HMSensor):

--- a/pyhomematic/devicetypes/thermostats.py
+++ b/pyhomematic/devicetypes/thermostats.py
@@ -164,7 +164,7 @@ class ThermostatWall(HMThermostat, AreaThermostat, HelperBatteryState, HelperRss
         self.ATTRIBUTENODE.update({"CONTROL_MODE": [2], "BATTERY_STATE": [2]})
 
 
-class ThermostatWall2(HMThermostat, AreaThermostat, HelperLowBat):
+class ThermostatWall2(HMThermostat, AreaThermostat):
     """
     HM-CC-TC
     ClimateControl-Wall Thermostat that measures temperature and allows to set a target temperature or use some automatic mode.

--- a/pyhomematic/exceptions.py
+++ b/pyhomematic/exceptions.py
@@ -2,11 +2,9 @@ class HMException(Exception):
     """
     Base exception for all exceptions pyhomeamtic will raise.
     """
-    pass
 
 
 class HMRpcException(HMException):
     """
     Exception for errors while communicating via XML-RPC.
     """
-    pass

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ def readme():
 
 PACKAGE_NAME = 'pyhomematic'
 HERE = os.path.abspath(os.path.dirname(__file__))
-VERSION = '0.1.52'
+VERSION = '0.1.53'
 
 PACKAGES = find_packages(exclude=['tests', 'tests.*', 'dist', 'build'])
 


### PR DESCRIPTION
This pull request:
- Fixes unknown parameter-errors (Issues: #153, #186)
- Adds support for SSL connections with CCU3
- Adds support for authentication with CCU3
- Adds support for hostnames as XML-RPC endpoints
- Adds support for HmIP-eTRV-B, HmIP-FDT, HB-UW-Sen-THPL-O, HB-UW-Sen-THPL-I, HmIP-B1

Changes for Home Assistant:
- New class: UniversalSensor
  - Home Assistant: DISCOVER_SENSORS
- Add `ssl` and `verify_ssl` options