### PR TITLE
Add support for the HB-UW-Sen-THPL-[OI] "Univeral Sensor"

### DIFF
--- a/pyhomematic/devicetypes/sensors.py
+++ b/pyhomematic/devicetypes/sensors.py
@@ -724,6 +724,23 @@ class IPBrightnessSensor(HMSensor, HelperRssiDevice):
         self.ATTRIBUTENODE.update({"OPERATING_VOLTAGE": [0]})
 
 
+class UniversalSensor(WeatherStation, HelperLowBat, HelperRssiPeer):
+    """Universal sensor. (https://wiki.fhem.de/wiki/Universalsensor)"""
+
+    def __init__(self, device_description, proxy, resolveparamsets=False):
+        super().__init__(device_description, proxy, resolveparamsets)
+
+        # init metadata
+        self.SENSORNODE.update({"BatteryVoltage": [1],
+                                "LUMINOSITY": [1]})
+
+    def get_luminosity(self, channel=None):
+        return float(self.getSensorData("LUMINOSITY", channel))
+
+    def get_battery_voltage(self, channel=None):
+        return float(self.getSensorData("BatteryVoltage", channel))
+
+
 DEVICETYPES = {
     "HM-Sec-SC": ShutterContact,
     "HM-Sec-SC-2": ShutterContact,
@@ -809,4 +826,6 @@ DEVICETYPES = {
     "HmIP-SPDR": IPPassageSensor,
     "IT-Old-Remote-1-Channel": SmartwareMotion,
     "HmIP-SLO": IPBrightnessSensor,
+    "HB-UW-Sen-THPL-O": UniversalSensor,
+    "HB-UW-Sen-THPL-I": UniversalSensor,
 }


### PR DESCRIPTION
This pull request:
- adds support for HomeMatic devices: HB-UW-Sen-THPL-O and HB-UW-Sen-THPL-I
  - More information here: https://wiki.fhem.de/wiki/Universalsensor
  - New class: UniversalSensor
  - Home Assistant: DISCOVER_SENSORS
