### PR TITLE
Adding HmIP-FDT IP Dimmer support.

### DIFF
--- a/pyhomematic/devicetypes/actors.py
+++ b/pyhomematic/devicetypes/actors.py
@@ -130,7 +130,9 @@ class IPDimmer(GenericDimmer):
     """
     @property
     def ELEMENT(self):
-        return [3]
+        if "PDT" in self._TYPE:
+            return [3]
+        return [2]
 
 
 class IPKeyDimmer(GenericDimmer, HelperWorking, HelperActionPress):
@@ -665,6 +667,7 @@ DEVICETYPES = {
     "HmIP-BSM": IPKeySwitchPowermeter,
     "HMIP-BDT": IPKeyDimmer,
     "HmIP-BDT": IPKeyDimmer,
+    "HmIP-FDT": IPDimmer,
     "HmIP-PDT": IPDimmer,
     "HM-Sec-Key": KeyMatic,
     "HM-Sec-Key-S": KeyMatic,


### PR DESCRIPTION
This pull request:
- adds support for HomeMatic device: HmIP-FDT
  - Home Assistant [platform](https://github.com/home-assistant/home-assistant/blob/0da3e737651a150c17016f43b5f9144deff7ddd7/homeassistant/components/homematic/__init__.py#L65): DISCOVER_LIGHTS