### PR TITLE
add IPThermostat HmIP-B1 to DEVICETYPES

### DIFF
--- a/pyhomematic/devicetypes/thermostats.py
+++ b/pyhomematic/devicetypes/thermostats.py
@@ -352,6 +352,7 @@ DEVICETYPES = {
     "HmIP-eTRV": IPThermostat,
     "HmIP-eTRV-2": IPThermostat,
     "HmIP-eTRV-B": IPThermostat,
+    "HmIP-eTRV-B1": IPThermostat,
     "HmIP-STHD": IPThermostatWall,
     "HmIP-STH": IPThermostatWall,
     "HmIP-WTH-2": IPThermostatWall,


### PR DESCRIPTION
This pull request:
- adds support for HomeMatic device: HmIP-B1
- does the following: Adds support for the IPThermostat HmIP-B1 sold by german discounter Lidl.

