### PR TITLE
All HmIP devices have the SABOTAGE DP on channel 0 (MAINTENANCE)

### DIFF
--- a/pyhomematic/devicetypes/helper.py
+++ b/pyhomematic/devicetypes/helper.py
@@ -21,7 +21,7 @@ class HelperSabotageIP(HMDevice):
         super().__init__(device_description, proxy, resolveparamsets)
 
         # init metadata
-        self.ATTRIBUTENODE.update({"SABOTAGE": self.ELEMENT})
+        self.ATTRIBUTENODE.update({"SABOTAGE": [0]})
 
     def sabotage(self, channel=None):
         """Returns True if the devicecase has been opened."""


### PR DESCRIPTION
Source:
https://www.eq-3.de/Downloads/eq3/download%20bereich/hm_web_ui_doku/HmIP_Device_Documentation.pdf

The same goes for LOW_BAT, but this was already fixed in
2a7c4577990ac051765f02267666173f77b3aa23
