### PR TITLE
Adds HmIP-SWDM to supported list

### DIFF
--- a/pyhomematic/devicetypes/sensors.py
+++ b/pyhomematic/devicetypes/sensors.py
@@ -752,6 +752,7 @@ DEVICETYPES = {
     "HMIP-SWDO": IPShutterContact,
     "HmIP-SWDO": IPShutterContact,
     "HmIP-SWDO-I": IPShutterContact,
+    "HmIP-SWDM": IPShutterContact,
     "HmIP-SRH": RotaryHandleSensorIP,
     "HM-Sec-RHS": RotaryHandleSensor,
     "ZEL STG RM FDK": RotaryHandleSensor,


### PR DESCRIPTION
This pull request:
- adds support for HomeMatic device: 'HmIP-SWDM'

This is the new window sensor that comes with the cheaper HmIP radiator thermostat.
