### PR TITLE
HmIP-FBL added

### DIFF
--- a/pyhomematic/devicetypes/actors.py
+++ b/pyhomematic/devicetypes/actors.py
@@ -558,6 +558,7 @@ DEVICETYPES = {
     "HmIP-BROLL": IPKeyBlind,
     "HmIP-FROLL": IPKeyBlind,
     "HmIP-BBL": IPKeyBlindTilt,
+    "HmIP-FBL": IPKeyBlindTilt,
     "HM-LC-Dim1L-Pl": Dimmer,
     "HM-LC-Dim1L-Pl-2": Dimmer,
     "HM-LC-Dim1L-Pl-3": Dimmer,


### PR DESCRIPTION
This pull request:
- adds support for HomeMatic device: HmIP-FBL Blind actor with tilt
HmIP-FBL seems to be compatible with IPKeyBlindTilt. Basic functions (open/close cover, open/close tilt) tested via home-assistant.
Used versions: 
- pyhomematic 0.1.52
- home-assistant 0.83.3
