### PR TITLE
0.1.54

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,9 @@
-Version 0.1.54 ()
+Version 0.1.54 (2018-12-30)
+- Set SABOTAGE helper for HmIP devices to channel 0 @rgriebl
+- Fix log-message for callbacks @danielperna84
+- Add support for HmIP-FBL @Alex-ala
+- Add support for HmIP-SWDM @leoMehlig
+- Add support for HmIP-SMI55 @janbrummer
 
 Version 0.1.53 (2018-12-05)
 - Changed loglevel for getValue to `warning` (Issue #153) @danielperna84

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,5 @@
+Version 0.1.54 ()
+
 Version 0.1.53 (2018-12-05)
 - Changed loglevel for getValue to `warning` (Issue #153) @danielperna84
 - Channel for LOW_BAT always is 0 for HmIP devices (Issue #186) @danielperna84

--- a/pyhomematic/devicetypes/actors.py
+++ b/pyhomematic/devicetypes/actors.py
@@ -559,6 +559,7 @@ DEVICETYPES = {
     "HmIP-BROLL": IPKeyBlind,
     "HmIP-FROLL": IPKeyBlind,
     "HmIP-BBL": IPKeyBlindTilt,
+    "HmIP-FBL": IPKeyBlindTilt,
     "HM-LC-Dim1L-Pl": Dimmer,
     "HM-LC-Dim1L-Pl-2": Dimmer,
     "HM-LC-Dim1L-Pl-3": Dimmer,

--- a/pyhomematic/devicetypes/generic.py
+++ b/pyhomematic/devicetypes/generic.py
@@ -62,7 +62,7 @@ class HMGeneric():
         self._VALUES[key] = value   # Cache the value
 
         for callback in self._eventcallbacks:
-            LOG.debug("HMDevice.event: Using callback %s " % str(callback))
+            LOG.debug("HMGeneric.event: Using callback %s " % str(callback))
             callback(self._ADDRESS, interface_id, key, value)
 
     def getParamsetDescription(self, paramset):

--- a/pyhomematic/devicetypes/helper.py
+++ b/pyhomematic/devicetypes/helper.py
@@ -21,7 +21,7 @@ class HelperSabotageIP(HMDevice):
         super().__init__(device_description, proxy, resolveparamsets)
 
         # init metadata
-        self.ATTRIBUTENODE.update({"SABOTAGE": self.ELEMENT})
+        self.ATTRIBUTENODE.update({"SABOTAGE": [0]})
 
     def sabotage(self, channel=None):
         """Returns True if the devicecase has been opened."""

--- a/pyhomematic/devicetypes/sensors.py
+++ b/pyhomematic/devicetypes/sensors.py
@@ -787,6 +787,7 @@ DEVICETYPES = {
     "HMIP-SWDO": IPShutterContact,
     "HmIP-SWDO": IPShutterContact,
     "HmIP-SWDO-I": IPShutterContact,
+    "HmIP-SWDM": IPShutterContact,
     "HmIP-SRH": RotaryHandleSensorIP,
     "HM-Sec-RHS": RotaryHandleSensor,
     "ZEL STG RM FDK": RotaryHandleSensor,

--- a/pyhomematic/devicetypes/sensors.py
+++ b/pyhomematic/devicetypes/sensors.py
@@ -318,6 +318,41 @@ class MotionIP(HMBinarySensor, HMSensor):
         return [0, 1]
 
 
+class MotionIPV2(HMBinarySensor, HMSensor):
+    """Motion detection indoor 55 (rf ip)"""
+
+    def __init__(self, device_description, proxy, resolveparamsets=False):
+        super().__init__(device_description, proxy, resolveparamsets)
+
+        # init metadata
+        self.BINARYNODE.update({"MOTION_DETECTION_ACTIVE": [3], "MOTION": [3]})
+        self.SENSORNODE.update({"ILLUMINATION": [3]})
+        self.ATTRIBUTENODE.update({"LOW_BAT": [0], "ERROR_CODE": [0], "SABOTAGE": [0]})
+
+    def is_motion(self, channel=None):
+        """ Return True if motion is detected """
+        return bool(self.getBinaryData("MOTION", channel))
+
+    def is_motion_detection_active(self, channel=None):
+        return bool(self.getBinaryData("MOTION_DETECTION_ACTIVE", channel))
+
+    def get_brightness(self, channel=None):
+        """ Return brightness from 0 (dark) to 163830 (bright) """
+        return float(self.getSensorData("ILLUMINATION", channel))
+
+    def low_batt(self, channel=None):
+        """ Returns if the battery is low. """
+        return self.getAttributeData("LOW_BAT", channel)
+
+    def sabotage(self, channel=None):
+        """Returns True if the devicecase has been opened."""
+        return bool(self.getAttributeData("SABOTAGE", channel))
+
+    @property
+    def ELEMENT(self):
+        return [0, 1, 2, 3]
+
+
 class PresenceIP(HMBinarySensor, HMSensor):
     """Presence detection with HmIP-SPI"""
 
@@ -778,6 +813,7 @@ DEVICETYPES = {
     "263 162": MotionV2,
     "HM-Sec-MD": MotionV2,
     "HmIP-SMI": MotionIP,
+    "HmIP-SMI55": MotionIPV2,
     "HmIP-SMO": MotionIP,
     "HmIP-SMO-A": MotionIP,
     "HmIP-SPI": PresenceIP,

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ def readme():
 
 PACKAGE_NAME = 'pyhomematic'
 HERE = os.path.abspath(os.path.dirname(__file__))
-VERSION = '0.1.53'
+VERSION = '0.1.54'
 
 PACKAGES = find_packages(exclude=['tests', 'tests.*', 'dist', 'build'])
 


### PR DESCRIPTION
- set `SABOTAGE` for HmIP devices to channel `0`
- fix log message for callbacks
- adds support for devices: HmIP-FBL, HmIP-SWDM
- adds support for device: HmIP-SMI55 (#185)
  - New class: MotionIPV2
  - Home Assistant Platform: `DISCOVER_SENSORS`, `DISCOVER_BINARY_SENSORS`

Reminders:
- Consider solution for Issue #193 for changes required in Home Assistant.