### PR TITLE
Support for 4 button HmIP key ring remote

### DIFF
--- a/pyhomematic/devicetypes/misc.py
+++ b/pyhomematic/devicetypes/misc.py
@@ -38,7 +38,7 @@ class Remote(HMEvent, HelperEventRemote, HelperActionPress, HelperRssiPeer):
             return [1, 2, 3, 4]
         if "HM-PBI-4-FM" in self.TYPE or "ZEL STG RM FST UP4" in self.TYPE or "263 145" in self.TYPE or "HM-PBI-X" in self.TYPE:
             return [1, 2, 3, 4]
-        if "Sec4" in self.TYPE or "Key4" in self.TYPE or "KRCA" in self.TYPE:
+        if "Sec4" in self.TYPE or "Key4" in self.TYPE or "KRCA" in self.TYPE or "KRC4" in self.TYPE:
             return [1, 2, 3, 4]
         if "PB-6" in self.TYPE or "WRC6" in self.TYPE:
             return [1, 2, 3, 4, 5, 6]
@@ -123,6 +123,7 @@ DEVICETYPES = {
     "HmIP-WRC2": Remote,
     "HmIP-WRC6": Remote,
     "HmIP-KRCA": Remote,
+    "HmIP-KRC4": Remote,
     "HM-SwI-3-FM": RemotePress,
     "ZEL STG RM FSS UP3": RemotePress,
     "263 144": RemotePress,


### PR DESCRIPTION
The homematic IP key ring remote control - 4 buttons uses a different product identifier. With this change, the proper keypress events are generated.

(The buttons map to the channels as 2-1-4-3. I needed the workaround to create empty programs and execute them via the buttons once.)
