### PR TITLE
Wrong Helper used produces Exception

### DIFF
--- a/pyhomematic/devicetypes/sensors.py
+++ b/pyhomematic/devicetypes/sensors.py
@@ -18,7 +18,7 @@ class HMBinarySensor(HMDevice):
     pass
 
 
-class IPShutterContact(HMBinarySensor, HelperBinaryState, HelperLowBat):
+class IPShutterContact(HMBinarySensor, HelperBinaryState, HelperLowBatIP):
     """Door / Window contact that emits its open/closed state."""
     def is_open(self, channel=None):
         """ Returns True if the contact is open. """


### PR DESCRIPTION



This pull request:
- fixes issue: 

`Jan 31 20:14:30 hauto-hass hass[28645]: #033[33m2019-01-31 20:14:30 WARNING (Thread-3) [pyhomematic.devicetypes.generic] HMGeneric.getValue: LOWBAT on xxxxxxxFC8:1 Exception: <Fault -5: 'Unknown Parameter for value key: LOWBAT'>#033[0m`

- does the following: Prevents the exception
