### PR TITLE
 New master classes and Helper usage

### DIFF
--- a/pyhomematic/devicetypes/sensors.py
+++ b/pyhomematic/devicetypes/sensors.py
@@ -15,17 +15,31 @@ class HMSensor(HMDevice):
     """This class helps to resolve class inheritance order problems."""
 
 
+class SensorHmW(HMSensor):
+    """Homematic Wired sensors"""
+
+
 class SensorHm(HMSensor, HelperRssiDevice, HelperRssiPeer, HelperLowBat):
-    """Homematic sensors always publish their
-         signal strength the device (HelperRssiDevice)
-         low battery status (HelperLowBat)"""
+    """Homematic sensors always have
+         - strength of the signal received by the device (HelperRssiDevice).
+           Be aware that standard HM devices have a reversed understanding of PEER
+           and DEVICE compared to HMIP devices.
+         - strength of the signal received by the CCU (HelperRssiPeer).
+           Be aware that standard HM devices have a reversed understanding of PEER
+           and DEVICE compared to HMIP devices.
+         - low battery status (HelperLowBat)"""
 
 
 class SensorHmIP(HMSensor, HelperRssiDevice, HelperLowBatIP, HelperOperatingVoltageIP):
-    """Homematic IP sensors always publish their
-         signal strength the device (HelperRssiDevice)
-         low battery status (HelperLowBatIP)
-         voltage of the batteries (HelperOperatingVoltageIP)"""
+    """Homematic IP sensors always have
+         - strength of the signal received by the CCU (HelperRssiDevice).
+           Be aware that HMIP devices have a reversed understanding of PEER
+           and DEVICE compared to standard HM devices.
+         - strength of the signal received by the device (HelperRssiPeer).
+           Be aware that standard HMIP devices have a reversed understanding of PEER
+           and DEVICE compared to standard HM devices.
+         - low battery status (HelperLowBatIP)
+         - voltage of the batteries (HelperOperatingVoltageIP)"""
 
 
 class ShutterContact(SensorHm, HelperBinaryState, HelperSabotage):
@@ -223,7 +237,7 @@ class GongSensor(SensorHm):
         self.EVENTNODE.update({"PRESS_SHORT": self.ELEMENT})
 
 
-class WiredSensor(HMSensor, HelperWired):
+class WiredSensor(SensorHmW, HelperWired):
     """Wired binary Sensor."""
 
     def __init__(self, device_description, proxy, resolveparamsets=False):

--- a/pyhomematic/devicetypes/sensors.py
+++ b/pyhomematic/devicetypes/sensors.py
@@ -13,14 +13,12 @@ LOG = logging.getLogger(__name__)
 
 class HMSensor(HMDevice):
     """This class helps to resolve class inheritance order problems."""
-    pass
 
 
 class SensorHm(HMSensor, HelperRssiDevice, HelperRssiPeer, HelperLowBat):
     """Homematic sensors always publish their
          signal strength the device (HelperRssiDevice)
          low battery status (HelperLowBat)"""
-    pass
 
 
 class SensorHmIP(HMSensor, HelperRssiDevice, HelperLowBatIP, HelperOperatingVoltageIP):
@@ -28,7 +26,6 @@ class SensorHmIP(HMSensor, HelperRssiDevice, HelperLowBatIP, HelperOperatingVolt
          signal strength the device (HelperRssiDevice)
          low battery status (HelperLowBatIP)
          voltage of the batteries (HelperOperatingVoltageIP)"""
-    pass
 
 
 class ShutterContact(SensorHm, HelperBinaryState, HelperSabotage):

--- a/pyhomematic/devicetypes/sensors.py
+++ b/pyhomematic/devicetypes/sensors.py
@@ -11,12 +11,23 @@ from pyhomematic.devicetypes.helper import (HelperLowBat, HelperSabotage,
 LOG = logging.getLogger(__name__)
 
 
-class HMSensor(HMDevice):
+class SensorHm(HMDevice, HelperRssiDevice, HelperLowBat):
+    """Homematic sensors always publish their
+         signal strength the device (HelperRssiDevice)
+         low battery status (HelperLowBat)"""
     pass
 
 
-class HMBinarySensor(HMDevice):
+class SensorHmIP(HMDevice, HelperRssiDevice, HelperLowBatIP, HelperOperatingVoltageIP):
+    """Homematic IP sensors always publish their
+         signal strength the device (HelperRssiDevice)
+         low battery status (HelperLowBatIP)
+         voltage of the batteries (HelperOperatingVoltageIP)"""
     pass
+
+
+class ShutterContact(IPShutterContact, HelperSabotage, HelperRssiPeer):
+    """Door / Window contact that emits its open/closed state."""
 
 
 class IPShutterContact(HMBinarySensor, HelperBinaryState, HelperLowBatIP, HelperOperatingVoltageIP):
@@ -34,10 +45,6 @@ class IPShutterContact(HMBinarySensor, HelperBinaryState, HelperLowBatIP, Helper
         if "HM-SCI-3-FM" in self._TYPE:
             return [1, 2, 3]
         return [1]
-
-
-class ShutterContact(IPShutterContact, HelperSabotage, HelperRssiPeer):
-    """Door / Window contact that emits its open/closed state."""
 
 
 class MaxShutterContact(HMBinarySensor, HelperBinaryState, HelperLowBat):

--- a/pyhomematic/devicetypes/sensors.py
+++ b/pyhomematic/devicetypes/sensors.py
@@ -16,11 +16,10 @@ class HMSensor(HMDevice):
     pass
 
 
-class SensorHm(HMSensor, HelperRssiDevice, HelperLowBat):
+class SensorHm(HMSensor, HelperRssiDevice, HelperRssiPeer, HelperLowBat):
     """Homematic sensors always publish their
          signal strength the device (HelperRssiDevice)
          low battery status (HelperLowBat)"""
-
     pass
 
 
@@ -29,7 +28,6 @@ class SensorHmIP(HMSensor, HelperRssiDevice, HelperLowBatIP, HelperOperatingVolt
          signal strength the device (HelperRssiDevice)
          low battery status (HelperLowBatIP)
          voltage of the batteries (HelperOperatingVoltageIP)"""
-
     pass
 
 


### PR DESCRIPTION
I did not change any class names.

Now all standard Homematic sensors have the attributes:

- HelperRssiDevice
- HelperRssiPeer
- HelperLowBat

All HomematicIP sensors have the attributes:

- HelperRssiDevice
- HelperLowBatIP
- HelperOperatingVoltageIP

I have changed the use of main classes and it inheritance. The new top
class `SensorHm`, `SensorHmIP` include all Helper classes that are common
to all devices of the specific model line. `SensorHm` is for standard
Homematic devices and `SensorHmIP` for the newer IP version.

Also, the use of existing Helper classes is now implemented for all
sensor classes. to prepare for the next step of adding more Helper
classes and changing the class names I have partly copied the content of
a sensor class to a class that was until now inheriting a sensor class
of similar capability. An example is the Shutter class.
