### PR TITLE
0.1.57

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,5 @@
+Version 0.1.57 (2019-)
+
 Version 0.1.56 (2019-02-19)
 - Remove SABOTAGE from HmIP-SMO(-A) (Issue #212) @danielperna84
 - Fix resolving names with JSON with SSL @danielperna84

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
-Version 0.1.57 (2019-03-)
+Version 0.1.57 (2019-03-02)
 - Fix/add support for HmIP-WTH & HmIP-WTH-2 (Issue #223) @DieterChmod
+- Add support for HM-Sec-SFA-SM @danielperna84
 
 Version 0.1.56 (2019-02-19)
 - Remove SABOTAGE from HmIP-SMO(-A) (Issue #212) @danielperna84
@@ -11,7 +12,7 @@ Version 0.1.56 (2019-02-19)
 
 Version 0.1.55 (2019-01-24)
 - Add support for HmIP-MIOB @danielperna84
-- Add suppoer for HmIP-BSL @danielperna84
+- Add support for HmIP-BSL @danielperna84
 - Add support for HmIP-SWD @danielperna84
 - Add support for HmIP-BRC2 @hg8496
 - Add support for HmIP-KRC4 @l-mb

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,5 @@
-Version 0.1.57 (2019-)
+Version 0.1.57 (2019-03-)
+- Fix/add support for HmIP-WTH & HmIP-WTH-2 (Issue #223) @DieterChmod
 
 Version 0.1.56 (2019-02-19)
 - Remove SABOTAGE from HmIP-SMO(-A) (Issue #212) @danielperna84

--- a/pyhomematic/devicetypes/actors.py
+++ b/pyhomematic/devicetypes/actors.py
@@ -194,7 +194,7 @@ class Switch(GenericSwitch, HelperWorking, HelperRssiPeer):
     """
     @property
     def ELEMENT(self):
-        if "LC-Sw2" in self.TYPE:
+        if "LC-Sw2" in self.TYPE or "Sec-SFA-SM" in self.TYPE:
             return [1, 2]
         elif "LC-Sw4" in self.TYPE:
             return [1, 2, 3, 4]
@@ -680,6 +680,7 @@ DEVICETYPES = {
     "HM-MOD-Re-8": Switch,
     "IT-Switch": Switch,
     "REV-Ritter-Switch": Switch,
+    "HM-Sec-SFA-SM": Switch,
     "HM-ES-PMSw1-Pl": SwitchPowermeter,
     "HM-ES-PMSw1-Pl-DN-R1": SwitchPowermeter,
     "HM-ES-PMSw1-Pl-DN-R2": SwitchPowermeter,

--- a/pyhomematic/devicetypes/thermostats.py
+++ b/pyhomematic/devicetypes/thermostats.py
@@ -1,6 +1,6 @@
 import logging
 from pyhomematic.devicetypes.generic import HMDevice
-from pyhomematic.devicetypes.sensors import AreaThermostat
+from pyhomematic.devicetypes.sensors import AreaThermostat, IPAreaThermostat
 from pyhomematic.devicetypes.helper import HelperValveState, HelperBatteryState, HelperLowBat, HelperLowBatIP, HelperRssiPeer
 
 LOG = logging.getLogger(__name__)
@@ -334,6 +334,63 @@ class IPThermostatWall230V(HMThermostat):
         """ Turn off Thermostat. """
         self.writeNodeData("SET_POINT_TEMPERATURE", self.OFF_VALUE)
 
+class IPThermostatWall2(HMThermostat, IPAreaThermostat, HelperLowBatIP):
+    """
+    HmIP-WTH, HmIP-WTH-2
+    ClimateControl-Wall Thermostat that measures temperature and allows to set a target temperature or use some automatic mode.
+    """
+    def __init__(self, device_description, proxy, resolveparamsets=False):
+        super().__init__(device_description, proxy, resolveparamsets)
+
+        # init metadata
+        self.SENSORNODE.update({"ACTUAL_TEMPERATURE": [1],
+                                "HUMIDITY": [1]})
+        self.WRITENODE.update({"SET_POINT_TEMPERATURE": [1]})
+        self.ACTIONNODE.update({"AUTO_MODE": [1],
+                                "MANU_MODE": [1],
+                                "CONTROL_MODE": [1],
+                                "BOOST_MODE": [1]})
+        self.ATTRIBUTENODE.update({"LOW_BAT": [0],
+                                   "OPERATING_VOLTAGE": [0],
+                                   "SET_POINT_MODE": [1],
+                                   "BOOST_MODE": [1]})
+
+    def get_set_temperature(self):
+        """ Returns the current target temperature. """
+        return self.getWriteData("SET_POINT_TEMPERATURE")
+
+    def set_temperature(self, target_temperature):
+        """ Set the target temperature. """
+        try:
+            target_temperature = float(target_temperature)
+        except Exception as err:
+            LOG.debug("Thermostat.set_temperature: Exception %s" % (err,))
+            return False
+        self.writeNodeData("SET_POINT_TEMPERATURE", target_temperature)
+
+    @property
+    def MODE(self):
+        """ Return mode. """
+        if self.getAttributeData("BOOST_MODE"):
+            return self.BOOST_MODE
+        else:
+            return self.getAttributeData("SET_POINT_MODE")
+
+    @MODE.setter
+    def MODE(self, setmode):
+        """ Set mode. """
+        if setmode == self.BOOST_MODE:
+            self.actionNodeData('BOOST_MODE', True)
+        elif setmode in [self.AUTO_MODE, self.MANU_MODE]:
+            if self.getAttributeData("BOOST_MODE"):
+                self.actionNodeData('BOOST_MODE', False)
+            self.actionNodeData('CONTROL_MODE', setmode)
+
+    def turnoff(self):
+        """ Turn off Thermostat. """
+        self.writeNodeData("SET_POINT_TEMPERATURE", self.OFF_VALUE)
+
+
 DEVICETYPES = {
     "HM-CC-VG-1": ThermostatGroup,
     "HM-CC-RT-DN": Thermostat,
@@ -357,10 +414,10 @@ DEVICETYPES = {
     "HmIP-eTRV-B1": IPThermostat,
     "HmIP-STHD": IPThermostatWall,
     "HmIP-STH": IPThermostatWall,
-    "HmIP-WTH-2": IPThermostatWall,
-    "HMIP-WTH-2": IPThermostatWall,
-    "HMIP-WTH": IPThermostatWall,
-    "HmIP-WTH": IPThermostatWall,
+    "HmIP-WTH-2": IPThermostatWall2,
+    "HMIP-WTH-2": IPThermostatWall2,
+    "HMIP-WTH": IPThermostatWall2,
+    "HmIP-WTH": IPThermostatWall2,
     "HmIP-BWTH": IPThermostatWall230V,
     "HmIP-HEATING": IPThermostat,
 }

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ def readme():
 
 PACKAGE_NAME = 'pyhomematic'
 HERE = os.path.abspath(os.path.dirname(__file__))
-VERSION = '0.1.56'
+VERSION = '0.1.57'
 
 PACKAGES = find_packages(exclude=['tests', 'tests.*', 'dist', 'build'])
 


### PR DESCRIPTION
- Adds support for HomeMatic device: HmIP-WTH & HmIP-WTH-2
  - New class: IPThermostatWall2
  - Home Assistant [platform](https://github.com/home-assistant/home-assistant/blob/0da3e737651a150c17016f43b5f9144deff7ddd7/homeassistant/components/homematic/__init__.py#L65): DISCOVER_SENSORS and DISCOVER_CLIMATE
  - Add new class to `HM_IGNORE_DISCOVERY_NODE_EXCEPTIONS` in the component.
- The `IPThermostat` class should also be added to `DISCOVER_SENSORS` and `HM_IGNORE_DISCOVERY_NODE_EXCEPTIONS`
- Adds support for HM-Sec-SFA-SM