### PR TITLE
Added HmIP-BWTH24 support

### DIFF
--- a/pyhomematic/devicetypes/thermostats.py
+++ b/pyhomematic/devicetypes/thermostats.py
@@ -419,5 +419,6 @@ DEVICETYPES = {
     "HMIP-WTH": IPThermostatWall2,
     "HmIP-WTH": IPThermostatWall2,
     "HmIP-BWTH": IPThermostatWall230V,
+    "HmIP-BWTH24": IPThermostatWall230V,
     "HmIP-HEATING": IPThermostat,
 }


### PR DESCRIPTION
Hi Daniel,

first of all, thank you for your very nice work!

This PR adds support for the 24V version of the HmIP-BWTH wall thermostat with switching output. I've used your datapoints.py script to double check that the referenced values in "IPThermostatWall230V" are actually present in the paramsets of the nodes. I think the two versions 230V and 24V are pretty much the same thing API wise. 

The only complain that I have with this pull request is that referenced python method of the 24V version has a 230V in the name:
`"HmIP-BWTH24": IPThermostatWall230V`
I think this can be improved by renaming the method.

Thank you very much for you work & cheers,
Tim

