### PR TITLE
0.1.58

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,4 @@
-Version 0.1.58 (2019-03-)
+Version 0.1.58 (2019-03-12)
 - KeyMatic, add LOWBAT, move STATE_UNCERTAIN & ERROR to attributes (Issue #229) @danielperna84
 - Remove LOWBAT for specific motion detectors & Thermostats (Issue #230) @danielperna84
 - Remove SABOTAGE from some HmIP shutter contacts (Issue #230) @danielperna84

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,5 @@
+Version 0.1.58 (2019-)
+
 Version 0.1.57 (2019-03-02)
 - Fix/add support for HmIP-WTH & HmIP-WTH-2 (Issue #223) @DieterChmod
 - Add support for HM-Sec-SFA-SM @danielperna84

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 Version 0.1.58 (2019-)
 - KeyMatic, add LOWBAT, move STATE_UNCERTAIN & ERROR to attributes (Issue #229) @danielperna84
-- Remove LOWBAT for specific motion detectors (Issue #230) @danielperna84
+- Remove LOWBAT for specific motion detectors & Thermostats (Issue #230) @danielperna84
 
 Version 0.1.57 (2019-03-02)
 - Fix/add support for HmIP-WTH & HmIP-WTH-2 (Issue #223) @DieterChmod

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
-Version 0.1.58 (2019-)
+Version 0.1.58 (2019-03-)
 - KeyMatic, add LOWBAT, move STATE_UNCERTAIN & ERROR to attributes (Issue #229) @danielperna84
 - Remove LOWBAT for specific motion detectors & Thermostats (Issue #230) @danielperna84
+- Remove SABOTAGE from some HmIP shutter contacts (Issue #230) @danielperna84
 
 Version 0.1.57 (2019-03-02)
 - Fix/add support for HmIP-WTH & HmIP-WTH-2 (Issue #223) @DieterChmod

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 Version 0.1.58 (2019-)
 - KeyMatic, add LOWBAT, move STATE_UNCERTAIN & ERROR to attributes (Issue #229) @danielperna84
+- Remove LOWBAT for specific motion detectors (Issue #230) @danielperna84
 
 Version 0.1.57 (2019-03-02)
 - Fix/add support for HmIP-WTH & HmIP-WTH-2 (Issue #223) @DieterChmod

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,5 @@
 Version 0.1.58 (2019-)
+- KeyMatic, add LOWBAT, move STATE_UNCERTAIN & ERROR to attributes (Issue #229) @danielperna84
 
 Version 0.1.57 (2019-03-02)
 - Fix/add support for HmIP-WTH & HmIP-WTH-2 (Issue #223) @DieterChmod

--- a/pyhomematic/devicetypes/actors.py
+++ b/pyhomematic/devicetypes/actors.py
@@ -309,8 +309,9 @@ class KeyMatic(HMActor, HelperActorState, HelperRssiPeer):
 
         # init metadata
         self.ACTIONNODE.update({"OPEN": self.ELEMENT})
-        self.BINARYNODE.update({"STATE_UNCERTAIN": self.ELEMENT})
-        self.SENSORNODE.update({"ERROR": self.ELEMENT})
+        self.ATTRIBUTENODE.update({"STATE_UNCERTAIN": self.ELEMENT,
+                                   "ERROR": self.ELEMENT,
+                                   "LOWBAT": [0]})
 
     def is_unlocked(self, channel=None):
         """ Returns True if KeyMatic is unlocked. """

--- a/pyhomematic/devicetypes/sensors.py
+++ b/pyhomematic/devicetypes/sensors.py
@@ -71,7 +71,7 @@ class ShutterContact(SensorHm, HelperBinaryState, HelperSabotage):
         return [1]
 
 
-class IPShutterContact(SensorHmIP, HelperBinaryState, HelperSabotageIP):
+class IPShutterContact(SensorHmIP, HelperBinaryState):
     """Door / Window contact that emits its open/closed state.
        This is a binary sensor."""
 
@@ -82,6 +82,10 @@ class IPShutterContact(SensorHmIP, HelperBinaryState, HelperSabotageIP):
     def is_closed(self, channel=None):
         """ Returns True if the contact is closed. """
         return not self.get_state(channel)
+
+
+class IPShutterContactSabotage(IPShutterContact, HelperSabotageIP):
+    """Same as IPShutterContact, but with sabotage detection."""
 
 
 class MaxShutterContact(HelperBinaryState, HelperLowBat):
@@ -849,9 +853,9 @@ DEVICETYPES = {
     "BC-SC-Rd-WM-2": MaxShutterContact,
     "BC-SC-Rd-WM": MaxShutterContact,
     "HM-SCI-3-FM": ShutterContact,
-    "HMIP-SWDO": IPShutterContact,
-    "HmIP-SWDO": IPShutterContact,
-    "HmIP-SWDO-I": IPShutterContact,
+    "HMIP-SWDO": IPShutterContactSabotage,
+    "HmIP-SWDO": IPShutterContactSabotage,
+    "HmIP-SWDO-I": IPShutterContactSabotage,
     "HmIP-SWDM": IPShutterContact,
     "HmIP-SWDM-B2": IPShutterContact,
     "HmIP-SRH": RotaryHandleSensorIP,

--- a/pyhomematic/devicetypes/sensors.py
+++ b/pyhomematic/devicetypes/sensors.py
@@ -19,6 +19,16 @@ class SensorHmW(HMSensor):
     """Homematic Wired sensors"""
 
 
+class SensorHmNLB(HMSensor, HelperRssiDevice, HelperRssiPeer):
+    """Homematic sensors always have
+         - strength of the signal received by the device (HelperRssiDevice).
+           Be aware that standard HM devices have a reversed understanding of PEER
+           and DEVICE compared to HMIP devices.
+         - strength of the signal received by the CCU (HelperRssiPeer).
+           Be aware that standard HM devices have a reversed understanding of PEER
+           and DEVICE compared to HMIP devices."""
+
+
 class SensorHm(HMSensor, HelperRssiDevice, HelperRssiPeer, HelperLowBat):
     """Homematic sensors always have
          - strength of the signal received by the device (HelperRssiDevice).
@@ -290,7 +300,7 @@ class ValveDrive(SensorHm):
         return [1]
 
 
-class Motion(SensorHm):
+class Motion(SensorHmNLB):
     """Motion detection.
        This is a binary sensor."""
 

--- a/pyhomematic/devicetypes/sensors.py
+++ b/pyhomematic/devicetypes/sensors.py
@@ -508,7 +508,7 @@ class ImpulseSensor(HMEvent):
         self.EVENTNODE.update({"SEQUENCE_OK": self.ELEMENT})
 
 
-class AreaThermostat(SensorHm):
+class AreaThermostat(SensorHmNLB):
     """Wall mount thermostat."""
 
     def __init__(self, device_description, proxy, resolveparamsets=False):

--- a/pyhomematic/devicetypes/thermostats.py
+++ b/pyhomematic/devicetypes/thermostats.py
@@ -419,5 +419,6 @@ DEVICETYPES = {
     "HMIP-WTH": IPThermostatWall2,
     "HmIP-WTH": IPThermostatWall2,
     "HmIP-BWTH": IPThermostatWall230V,
+    "HmIP-BWTH24": IPThermostatWall230V,
     "HmIP-HEATING": IPThermostat,
 }

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ def readme():
 
 PACKAGE_NAME = 'pyhomematic'
 HERE = os.path.abspath(os.path.dirname(__file__))
-VERSION = '0.1.57'
+VERSION = '0.1.58'
 
 PACKAGES = find_packages(exclude=['tests', 'tests.*', 'dist', 'build'])
 


### PR DESCRIPTION
- KeyMatic, add LOWBAT, move STATE_UNCERTAIN & ERROR to attributes (Issue #229)
- Remove LOWBAT for specific motion detectors & Thermostats (Issue #230)
- Remove SABOTAGE from some HmIP shutter contacts (Issue #230)

Required changes in Home Assistant:
- Add `IPShutterContactSabotage` to `DISCOVER_BINARY_SENSORS`