### PR TITLE
Switched to using channel 3 for HmIP blind devices for requesting lev…

### DIFF
--- a/pyhomematic/devicetypes/actors.py
+++ b/pyhomematic/devicetypes/actors.py
@@ -66,6 +66,13 @@ class IPKeyBlind(KeyBlind):
     Blind switch that raises and lowers homematic ip roller shutters or window blinds.
     """
 
+    def get_level(self, channel=3):
+        """
+        Return current level. Return value is float() from 0.0 to 1.0.
+        Overrides inherited get_level() in order to use correct channel for requesting level state.
+        """
+        return self.getWriteData("LEVEL", channel)
+
     @property
     def ELEMENT(self):
         return [4]

--- a/pyhomematic/devicetypes/generic.py
+++ b/pyhomematic/devicetypes/generic.py
@@ -350,9 +350,9 @@ class HMDevice(HMGeneric):
         nodeChannel = None
         if name in metadata:
             nodeChannelList = metadata[name]
-            if len(nodeChannelList) > 1:
-                nodeChannel = channel if channel is not None else nodeChannelList[0]
-            elif len(nodeChannelList) == 1:
+            if channel is not None:
+                nodeChannel = channel
+            elif nodeChannelList:
                 nodeChannel = nodeChannelList[0]
             if nodeChannel is not None and nodeChannel in self.CHANNELS:
                 return self._hmchannels[nodeChannel].setValue(name, data)


### PR DESCRIPTION
…el state

This pull request:
- fixes issue: #241 

Overrides get_level() in IPKeyBlind so that when requesting the current level of the blind, the channel 3 is used instead of channel 4. Channel 3 is always the channel that holds the state of the level (see [docs](https://www.eq-3.de/Downloads/eq3/download%20bereich/hm_web_ui_doku/HmIP_Device_Documentation.pdf)).
Channel 4 works in most cases, but not if e.g. the expert mode is activated.

The change in generic.py allows callers of these method to actually use the override parameter channel, even if there is a channel in nodeChannelList given.

After this fix, it is possible to see the correct blind level even if the blind got controlled by the hardware device itself and not only if it was controlled via the API.