### PR TITLE
Fetch min. and max. temp. from Paramset

### DIFF
--- a/pyhomematic/devicetypes/thermostats.py
+++ b/pyhomematic/devicetypes/thermostats.py
@@ -6,11 +6,9 @@ from pyhomematic.devicetypes.helper import HelperValveState, HelperBatteryState,
 LOG = logging.getLogger(__name__)
 
 
+
 class HMThermostat(HMDevice):
-    """
-    HM-CC-RT-DN, HM-CC-RT-DN-BoM
-    ClimateControl-RadiatorThermostat that measures temperature and allows to set a target temperature or use some automatic mode.
-    """
+    """Base class for HomeMatic thermostats."""
     def __init__(self, device_description, proxy, resolveparamsets=False):
         super().__init__(device_description, proxy, resolveparamsets)
 
@@ -21,7 +19,13 @@ class HMThermostat(HMDevice):
         self.BOOST_MODE = 3
         self.COMFORT_MODE = 4
         self.LOWERING_MODE = 5
-        self.OFF_VALUE = 4.5
+        if "HMIP" in self.TYPE.upper():
+            self.OFF_VALUE = self._proxy.getParamset("%s:1" % self._ADDRESS, "MASTER").get("TEMPERATURE_MINIMUM", 4.5)
+            self.MAX = self._proxy.getParamset("%s:1" % self._ADDRESS, "MASTER").get("TEMPERATURE_MAXIMUM", 30.5)
+        else:
+            self.OFF_VALUE = self._proxy.getParamset("%s" % self._ADDRESS, "MASTER").get("TEMPERATURE_MINIMUM", 4.5)
+            self.MAX = self._proxy.getParamset("%s" % self._ADDRESS, "MASTER").get("TEMPERATURE_MAXIMUM", 30.5)
+        self.MIN = self.OFF_VALUE + 0.5
 
         self.mode = None
 

--- a/pyhomematic/devicetypes/thermostats.py
+++ b/pyhomematic/devicetypes/thermostats.py
@@ -21,11 +21,12 @@ class HMThermostat(HMDevice):
         self.LOWERING_MODE = 5
         if "HMIP" in self.TYPE.upper():
             self.OFF_VALUE = self._proxy.getParamset("%s:1" % self._ADDRESS, "MASTER").get("TEMPERATURE_MINIMUM", 4.5)
-            self.MAX = self._proxy.getParamset("%s:1" % self._ADDRESS, "MASTER").get("TEMPERATURE_MAXIMUM", 30.5)
+            self.ON_VALUE = self._proxy.getParamset("%s:1" % self._ADDRESS, "MASTER").get("TEMPERATURE_MAXIMUM", 30.5)
         else:
             self.OFF_VALUE = self._proxy.getParamset("%s" % self._ADDRESS, "MASTER").get("TEMPERATURE_MINIMUM", 4.5)
-            self.MAX = self._proxy.getParamset("%s" % self._ADDRESS, "MASTER").get("TEMPERATURE_MAXIMUM", 30.5)
+            self.ON_VALUE = self._proxy.getParamset("%s" % self._ADDRESS, "MASTER").get("TEMPERATURE_MAXIMUM", 30.5)
         self.MIN = self.OFF_VALUE + 0.5
+        self.MAX = self.ON_VALUE - 0.5
 
         self.mode = None
 


### PR DESCRIPTION
Fetching `TEMPERATURE_MINIMUM` and `TEMPERATURE_MAXIMUM` from paramset. For regular HM-devices we get this by not specifying a channel, for HmIP it's at channel `1`.

For regular HM-Devices the default paramdata looks like this:  
`{'MAX': 14.5, 'OPERATIONS': 3, 'UNIT': '°C', 'DEFAULT': 4.5, 'MIN': 4.5, 'ID': 'TEMPERATURE_MINIMUM', 'TAB_ORDER': 12, 'FLAGS': 1, 'TYPE': 'FLOAT'}`

`{'MAX': 30.5, 'OPERATIONS': 3, 'UNIT': '°C', 'DEFAULT': 30.5, 'MIN': 15.0, 'ID': 'TEMPERATURE_MAXIMUM', 'TAB_ORDER': 13, 'FLAGS': 1, 'TYPE': 'FLOAT'}`

For HMIP the documentation shows this table (`TEMPERATURE_MAXIMUM`) :  

| Parameter | Value | Type | Operations | Default | Min. | Max. |
| --- | --- | --- | --- | --- | --- | --- |
| TEMPERATURE_MINIMUM | FLOAT | integer | read / write | 4.5 / 5.0 | 4.5 | 14.5 |
| TEMPERATURE_MAXIMUM | FLOAT | integer | read / write | 30.5 | 15.0 | 30.5 |

So it's actually identical by default (with HmIP some have 5.0 as the default). But it can be customized per device, so we should always fetch it from the paramset.

@pvizeli 
You said that about the 5.0 value. But by fetching the value it actually doesn't matter what type of device it is. So I think we can safely assume, that what we get as `TEMPERATURE_MINIMUM` is _off_. The CCU also displays the `TEMPERATURE_MAXIMUM` as _Ein_, so the max value could be mapped to _on_ in HASS. Everything between 4.5 (off) and 30.5 (on) can be interpreted as _try to reach the set temperature and stop when you have it_, whereas 30.5 probably is like a continous boost mode. So what I have set to `self.MAX` could also be `self.ON_VALUE`, and `self.MAX` could be the max minus 0.5, so like the minimum, just the other direction.

What do you think?