### PR TITLE
Add output support to HMW-IO-12-FM

### DIFF
--- a/pyhomematic/devicetypes/actors.py
+++ b/pyhomematic/devicetypes/actors.py
@@ -214,10 +214,20 @@ class IOSwitch(GenericSwitch, HelperWorking, HelperEventRemote, HelperWired):
     Switch turning attached device on or off.
     """
 
+    def __init__(self, device_description, proxy, resolveparamsets=False):
+        self._doc = []
+        super().__init__(device_description, proxy, resolveparamsets)
+        if "HMW-IO-12-FM" in self.TYPE:
+            for chan in range(1, 13):
+                if self._proxy.getParamset("%s:%i" % (self._ADDRESS, chan), "MASTER").get("BEHAVIOUR", None) == 1:
+                    self._doc.append(chan)
+
     @property
     def ELEMENT(self):
         if "HMW-IO-12-Sw7-DR" in self.TYPE:
             return [13, 14, 15, 16, 17, 18, 19]
+        if "HMW-IO-12-FM" in self.TYPE:
+            return self._doc
         if "HMW-LC-Sw2-DR" in self.TYPE:
             return [3, 4]
         return [1]
@@ -790,6 +800,7 @@ DEVICETYPES = {
     "HM-ES-PMSwX": SwitchPowermeter,
     "HMW-IO-12-Sw7-DR": IOSwitch,
     "HMW-IO-12-Sw14-DR": HMWIOSwitch,
+    "HMW-IO-12-FM": IOSwitch,
     "HMW-LC-Sw2-DR": IOSwitch,
     "HMW-LC-Bl1-DR": KeyBlind,
     "HMW-LC-Bl1-DR-2": KeyBlind,

--- a/pyhomematic/devicetypes/misc.py
+++ b/pyhomematic/devicetypes/misc.py
@@ -54,8 +54,6 @@ class Remote(HMEvent, HelperEventRemote, HelperActionPress, HelperRssiPeer):
             return list(range(1, 20))
         if "HMW-IO-4-FM" in self.TYPE:
             return [1, 2, 3, 4]
-        if "HMW-IO-12-FM" in self.TYPE:
-            return [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
         if "HmIP-RC8" in self.TYPE:
             return [1, 2, 3, 4, 5, 6, 7, 8]
         return [1]
@@ -136,7 +134,6 @@ DEVICETYPES = {
     "HM-PB-4Dis-WM": Remote,
     "HM-PB-4Dis-WM-2": Remote,
     "HMW-IO-4-FM": Remote,
-    "HMW-IO-12-FM": Remote,
     "HMIP-WRC2": RemoteBatteryIP,
     "HmIP-WRC2": RemoteBatteryIP,
     "HmIP-BRC2": Remote,


### PR DESCRIPTION
This pull request:
- fixes issue:  --- 
- adds support for HomeMatic device: HMW-IO-12-FM
  - New class: Added to IOSwitch
  - Home Assistant [platform](https://github.com/home-assistant/home-assistant/blob/0da3e737651a150c17016f43b5f9144deff7ddd7/homeassistant/components/homematic/__init__.py#L65): Not necessary as its an instance of IOSwitch
- does the following: Adds missing support for output part of HMW-IO-12-FM (single channels can be set to output, e.g. for LEDs in multiswitches)
