### PR TITLE
Update class IPThermostatWall230V

### DIFF
--- a/pyhomematic/devicetypes/thermostats.py
+++ b/pyhomematic/devicetypes/thermostats.py
@@ -305,9 +305,9 @@ class IPThermostatWall(HMThermostat, HelperLowBatIP):
         """ Turn off Thermostat. """
         self.writeNodeData("SET_POINT_TEMPERATURE", self.OFF_VALUE)
 
-class IPThermostatWall230V(HMThermostat):
+class IPThermostatWall230V(HMThermostat, IPAreaThermostat):
     """
-    HmIP-BWTH
+    HmIP-BWTH, HmIP-BWTH24
     ClimateControl-Wall Thermostat that measures temperature and allows to set a target temperature or use some automatic mode.
     """
     def __init__(self, device_description, proxy, resolveparamsets=False):
@@ -317,8 +317,12 @@ class IPThermostatWall230V(HMThermostat):
         self.SENSORNODE.update({"ACTUAL_TEMPERATURE": [1],
                                 "HUMIDITY": [1]})
         self.WRITENODE.update({"SET_POINT_TEMPERATURE": [1]})
-        self.ACTIONNODE.update({"BOOST_MODE": [1]})
-        self.ATTRIBUTENODE.update({"SET_POINT_MODE": [1]})
+        self.ACTIONNODE.update({"AUTO_MODE": [1],
+                                "MANU_MODE": [1],
+                                "CONTROL_MODE": [1],
+                                "BOOST_MODE": [1]})
+        self.ATTRIBUTENODE.update({"SET_POINT_MODE": [1],
+                                   "BOOST_MODE": [1]})
 
     def get_set_temperature(self):
         """ Returns the current target temperature. """
@@ -333,10 +337,28 @@ class IPThermostatWall230V(HMThermostat):
             return False
         self.writeNodeData("SET_POINT_TEMPERATURE", target_temperature)
 
+    @property
+    def MODE(self):
+        """ Return mode. """
+        if self.getAttributeData("BOOST_MODE"):
+            return self.BOOST_MODE
+        else:
+            return self.getAttributeData("SET_POINT_MODE")
+
+    @MODE.setter
+    def MODE(self, setmode):
+        """ Set mode. """
+        if setmode == self.BOOST_MODE:
+            self.actionNodeData('BOOST_MODE', True)
+        elif setmode in [self.AUTO_MODE, self.MANU_MODE]:
+            if self.getAttributeData("BOOST_MODE"):
+                self.actionNodeData('BOOST_MODE', False)
+            self.actionNodeData('CONTROL_MODE', setmode)
+
     def turnoff(self):
         """ Turn off Thermostat. """
         self.writeNodeData("SET_POINT_TEMPERATURE", self.OFF_VALUE)
-
+        
 class IPThermostatWall2(HMThermostat, IPAreaThermostat, HelperLowBatIP):
     """
     HmIP-WTH, HmIP-WTH-2

--- a/pyhomematic/devicetypes/thermostats.py
+++ b/pyhomematic/devicetypes/thermostats.py
@@ -358,7 +358,7 @@ class IPThermostatWall230V(HMThermostat, IPAreaThermostat):
     def turnoff(self):
         """ Turn off Thermostat. """
         self.writeNodeData("SET_POINT_TEMPERATURE", self.OFF_VALUE)
-        
+
 class IPThermostatWall2(HMThermostat, IPAreaThermostat, HelperLowBatIP):
     """
     HmIP-WTH, HmIP-WTH-2


### PR DESCRIPTION
Used class `IPThermostatWall2` as template for `IPThermostatWall230V`. Removed `OPERATING_VOLTAGE`,  `LOW_BAT` and `HelperLowBatIP`.

This pull request:
- fixes issue: #270 
- does the following: Update IPThermostatWall230V class
