### PR TITLE
Support for HmIP-MOD-HO (Hoermann Module)

### DIFF
--- a/pyhomematic/devicetypes/actors.py
+++ b/pyhomematic/devicetypes/actors.py
@@ -552,7 +552,7 @@ class IPKeySwitchPowermeter(IPSwitchPowermeter, HMEvent, HelperActionPress):
 
 class IPGarage(GenericSwitch, HMSensor):
     """
-    HmIP-MOD-TM Garage actor
+    HmIP-MOD-HO and HmIP-MOD-TM Garage actor
     """
     def __init__(self, device_description, proxy, resolveparamsets=False):
         super().__init__(device_description, proxy, resolveparamsets)
@@ -834,6 +834,7 @@ DEVICETYPES = {
     "HM-Sen-RD-O": Rain,
     "ST6-SH": EcoLogic,
     "HM-Sec-Sir-WM": RFSiren,
+    "HmIP-MOD-HO": IPGarage,
     "HmIP-MOD-TM": IPGarage,
     "HM-LC-RGBW-WM": ColorEffectLight,
     "HmIP-MIOB": IPMultiIO,


### PR DESCRIPTION
This pull request:
- adds support for HomeMatic IP device: HmIP-MOD-HO
  - Existing class: IPGarage

The [device documentations](https://www.eq-3.de/downloads/download/homematic/hm_web_ui_doku/HmIP_Device_Documentation.pdf) for HmIP-MOD-TM and HmIP-MOD-HO are identical.