### PR TITLE
Support window state for IP thermostats

### DIFF
--- a/manual_test.py
+++ b/manual_test.py
@@ -3,9 +3,10 @@ import sys
 import logging
 import click
 from pyhomematic import HMConnection
-from pyhomematic.devicetypes.sensors import WeatherSensor, AreaThermostat, ShutterContact, Smoke, Motion, Remote
-from pyhomematic.devicetypes.helper import HelperLowBat, HelperSabotage, HelperWorking, HelperBatteryState, HelperValveState
 from pyhomematic.devicetypes.actors import GenericSwitch
+from pyhomematic.devicetypes.helper import HelperLowBat, HelperSabotage, HelperWorking, HelperBatteryState, HelperValveState
+from pyhomematic.devicetypes.sensors import WeatherSensor, AreaThermostat, ShutterContact, Smoke, Motion, Remote
+from pyhomematic.devicetypes.thermostats import HMThermostat, IPThermostat
 
 
 def systemcallback(src, *args):
@@ -139,6 +140,14 @@ def cli(local, localport, remote, remoteport, address, channel, state, toggle,
                 device.set_state(bool(state), channel)
                 print(" / Switch is on: %s" % str(device.is_on(channel)))
 
+        # Thermostat
+        if isinstance(device, HMThermostat):
+            print(" / Working mode: %i" % device.MODE)
+            print(" / Target temperature: %.1f" % device.get_set_temperature())
+            print(" / Actual temperature: %.1f" % device.actual_temperature())
+        if isinstance(device, IPThermostat):
+            print(" / Window is opened: %s" % str(bool(device.get_window_state())))
+
         ########### Attribute #########
         print(" / RSSI_PEER: %i" % device.get_rssi())
 
@@ -155,7 +164,7 @@ def cli(local, localport, remote, remoteport, address, channel, state, toggle,
             print(" / Valve state: %i" % device.valve_state())
 
         if isinstance(device, HelperBatteryState):
-            print(" / Bettery state: %f" % device.battery_state())
+            print(" / Battery state: %f" % device.battery_state())
 
     # do nothing for show & debug events
     print("Now waiting for events/callback")

--- a/pyhomematic/devicetypes/thermostats.py
+++ b/pyhomematic/devicetypes/thermostats.py
@@ -225,7 +225,8 @@ class IPThermostat(HMThermostat, HelperLowBatIP, HelperValveState):
 
         # init metadata
         self.SENSORNODE.update({"ACTUAL_TEMPERATURE": [1]})
-        self.WRITENODE.update({"SET_POINT_TEMPERATURE": [1]})
+        self.WRITENODE.update({"SET_POINT_TEMPERATURE": [1],
+                               "WINDOW_STATE": [1]})
         self.ACTIONNODE.update({"AUTO_MODE": [1],
                                 "MANU_MODE": [1],
                                 "CONTROL_MODE": [1],
@@ -249,6 +250,19 @@ class IPThermostat(HMThermostat, HelperLowBatIP, HelperValveState):
             LOG.debug("Thermostat.set_temperature: Exception %s" % (err,))
             return False
         self.writeNodeData("SET_POINT_TEMPERATURE", target_temperature)
+
+    def get_window_state(self):
+        """ Returns the current window state. """
+        return self.getWriteData("WINDOW_STATE")
+
+    def set_window_state(self, target_state):
+        """ Set the target window state. """
+        try:
+            target_state = int(target_state)
+        except Exception as err:
+            LOG.debug("Thermostat.set_window_state: Exception %s" % (err,))
+            return False
+        self.writeNodeData("WINDOW_STATE", target_state)
 
     @property
     def MODE(self):


### PR DESCRIPTION
For IP thermostats it's possible to [get/set window state](https://www.eq-3.de/Downloads/eq3/download%20bereich/hm_web_ui_doku/HmIP_Device_Documentation.pdf) via `WINDOW_STATE` parameter to integrate them with 3rd party door/window sensors.

This pull request:
- adds support for getting/setting `WINDOW_STATE` value like that:

```
device.get_window_state(int_value)
device.set_window_state() -> int_value
```