### PR TITLE
Update sensors.py

### DIFF
--- a/pyhomematic/devicetypes/sensors.py
+++ b/pyhomematic/devicetypes/sensors.py
@@ -263,7 +263,7 @@ class WiredSensor(SensorHmW, HelperWired):
     def __init__(self, device_description, proxy, resolveparamsets=False):
         super().__init__(device_description, proxy, resolveparamsets)
 
-        self.EVENTNODE.update({"SENSOR": self.ELEMENT})
+        self.BINARYNODE.update({"SENSOR": self.ELEMENT})
 
     @property
     def ELEMENT(self):


### PR DESCRIPTION
This pull request:
- fixes issue: no tracked issue
- does the following: Fixes displaying Homematic Wired Sensor HMW-Sen-SC-12-DR

Tested with HMW-Sen-SC-12-DR and Home Assistant 0.104.3
Before the change the sensor was not discovered.

@reviewer
please have a look at my second commit comment, if this should be changed too.