### PR TITLE
HmIP thermostat attributes and smoke detector voltage fix

### DIFF
--- a/pyhomematic/devicetypes/sensors.py
+++ b/pyhomematic/devicetypes/sensors.py
@@ -52,6 +52,17 @@ class SensorHmIP(HMSensor, HelperRssiDevice, HelperLowBatIP, HelperOperatingVolt
          - low battery status (HelperLowBatIP)
          - voltage of the batteries (HelperOperatingVoltageIP)"""
 
+class SensorHmIPNoVoltage(HMSensor, HelperRssiDevice, HelperLowBatIP):
+    """Some Homematic IP sensors have
+         - strength of the signal received by the CCU (HelperRssiDevice).
+           Be aware that HMIP devices have a reversed understanding of PEER
+           and DEVICE compared to standard HM devices.
+         - strength of the signal received by the device (HelperRssiPeer).
+           Be aware that standard HMIP devices have a reversed understanding of PEER
+           and DEVICE compared to standard HM devices.
+         - low battery status (HelperLowBatIP)
+         - but no voltage of batteries"""
+
 
 class ShutterContact(SensorHm, HelperBinaryState, HelperSabotage):
     """Door / Window contact that emits its open/closed state.
@@ -233,7 +244,7 @@ class SmokeV2(SensorHm, HelperBinaryState):
         return self.get_state(channel)
 
 
-class IPSmoke(SensorHmIP):
+class IPSmoke(SensorHmIPNoVoltage):
     """HomeMatic IP Smoke sensor."""
 
     def __init__(self, device_description, proxy, resolveparamsets=False):

--- a/pyhomematic/devicetypes/thermostats.py
+++ b/pyhomematic/devicetypes/thermostats.py
@@ -1,7 +1,7 @@
 import logging
 from pyhomematic.devicetypes.generic import HMDevice
 from pyhomematic.devicetypes.sensors import AreaThermostat, IPAreaThermostat
-from pyhomematic.devicetypes.helper import HelperValveState, HelperBatteryState, HelperLowBat, HelperLowBatIP, HelperRssiPeer
+from pyhomematic.devicetypes.helper import HelperValveState, HelperBatteryState, HelperLowBat, HelperLowBatIP, HelperRssiPeer, HelperRssiDevice
 
 LOG = logging.getLogger(__name__)
 
@@ -215,7 +215,7 @@ class MAXWallThermostat(HMThermostat, HelperLowBat):
                                 "BOOST_MODE": [1]})
         self.ATTRIBUTENODE.update({"LOWBAT": [0], "CONTROL_MODE": [1]})
 
-class IPThermostat(HMThermostat, HelperLowBatIP, HelperValveState):
+class IPThermostat(HMThermostat, HelperRssiDevice, HelperLowBatIP, HelperValveState):
     """
     HPIM-eTRV
     ClimateControl-Radiator Thermostat that measures temperature and allows to set a target temperature or use some automatic mode.
@@ -286,7 +286,7 @@ class IPThermostat(HMThermostat, HelperLowBatIP, HelperValveState):
         """ Turn off Thermostat. """
         self.writeNodeData("SET_POINT_TEMPERATURE", self.OFF_VALUE)
 
-class IPThermostatWall(HMThermostat, HelperLowBatIP):
+class IPThermostatWall(HMThermostat, IPAreaThermostat, HelperRssiDevice, HelperLowBatIP):
     """
     HmIP-STHD
     ClimateControl-Wall Thermostat that measures temperature and allows to set a target temperature or use some automatic mode.
@@ -300,7 +300,9 @@ class IPThermostatWall(HMThermostat, HelperLowBatIP):
         self.WRITENODE.update({"SET_POINT_TEMPERATURE": [1]})
         self.ACTIONNODE.update({"BOOST_MODE": [1]})
         self.ATTRIBUTENODE.update({"LOW_BAT": [0],
-                                   "SET_POINT_MODE": [1]})
+                                   "OPERATING_VOLTAGE": [0],
+                                   "SET_POINT_MODE": [1],
+                                   "BOOST_MODE": [1]})
 
     def get_set_temperature(self):
         """ Returns the current target temperature. """
@@ -319,7 +321,7 @@ class IPThermostatWall(HMThermostat, HelperLowBatIP):
         """ Turn off Thermostat. """
         self.writeNodeData("SET_POINT_TEMPERATURE", self.OFF_VALUE)
 
-class IPThermostatWall230V(HMThermostat, IPAreaThermostat):
+class IPThermostatWall230V(HMThermostat, IPAreaThermostat, HelperRssiDevice):
     """
     HmIP-BWTH, HmIP-BWTH24
     ClimateControl-Wall Thermostat that measures temperature and allows to set a target temperature or use some automatic mode.
@@ -373,7 +375,7 @@ class IPThermostatWall230V(HMThermostat, IPAreaThermostat):
         """ Turn off Thermostat. """
         self.writeNodeData("SET_POINT_TEMPERATURE", self.OFF_VALUE)
 
-class IPThermostatWall2(HMThermostat, IPAreaThermostat, HelperLowBatIP):
+class IPThermostatWall2(HMThermostat, IPAreaThermostat, HelperRssiDevice, HelperLowBatIP):
     """
     HmIP-WTH, HmIP-WTH-2
     ClimateControl-Wall Thermostat that measures temperature and allows to set a target temperature or use some automatic mode.


### PR DESCRIPTION
- Add RSSI_DEVICE for all HmIP thermostats and OPERATING_VOLTAGE for HmIP-STH(D) wall thermostats
- Remove OPERATING_VOLTAGE from HmIP Smoke Detectors as they have a built-in battery which voltage is not reported by the CCU (gives WARNING during Home Assistant startup)