### PR TITLE
Add support for HmIP-WTH-B

### DIFF
--- a/pyhomematic/devicetypes/thermostats.py
+++ b/pyhomematic/devicetypes/thermostats.py
@@ -456,6 +456,8 @@ DEVICETYPES = {
     "HmIP-STH": IPThermostatWall,
     "HmIP-WTH-2": IPThermostatWall2,
     "HMIP-WTH-2": IPThermostatWall2,
+    "HmIP-WTH-B": IPThermostatWall2,
+    "HMIP-WTH-B": IPThermostatWall2,
     "HMIP-WTH": IPThermostatWall2,
     "HmIP-WTH": IPThermostatWall2,
     "HmIP-BWTH": IPThermostatWall230V,


### PR DESCRIPTION
Add support for this device by adding the device type to the list in thermostat.py.
The data points are already supported by IPThermostatWall2.

This pull request:
- adds support for HomeMatic device: HmIP-WTH-B (https://de.elv.com/homematic-ip-wandthermostat-basic-hmip-wth-b-154666)