### PR TITLE
Add support for HmIP-WRCD

### DIFF
--- a/pyhomematic/devicetypes/misc.py
+++ b/pyhomematic/devicetypes/misc.py
@@ -56,6 +56,8 @@ class Remote(HMEvent, HelperEventRemote, HelperActionPress, HelperRssiPeer):
             return [1, 2, 3, 4]
         if "HmIP-RC8" in self.TYPE:
             return [1, 2, 3, 4, 5, 6, 7, 8]
+        if "HmIP-WRCD" in self.TYPE:
+            return [1, 2, 3]
         return [1]
 
 
@@ -138,6 +140,7 @@ DEVICETYPES = {
     "HmIP-WRC2": RemoteBatteryIP,
     "HmIP-BRC2": Remote,
     "HmIP-WRC6": RemoteBatteryIP,
+    "HmIP-WRCD": RemoteBatteryIP,
     "HmIP-KRCA": Remote,
     "HmIP-KRC4": Remote,
     "HM-SwI-3-FM": RemotePress,


### PR DESCRIPTION
This pull request:
- adds support for HomeMatic device: HmIP-WRCD

Ba

Channels: 
1: Button
2: Button
3: COMBINED_PARAMETER for setting e-paper display output or sound, cann be targeted by set_device_value

Example to send a sound from HomeAssistant:
```yaml
service: homematic.set_device_value
data:
  value: '{R=2,IN=20,ANS=4}'
  address: 002A5A49C0FFEE
  channel: 3
  param: COMBINED_PARAMETER
  interface: ip
```
or setting display lines with an icon.
```yaml
service: homematic.set_device_value
data:
  value: '{DDBC=WHITE,DDTC=BLACK,DDI=23,DDA=CENTER,DDS=Line 2,DDID=2},{DDBC=WHITE,DDTC=BLACK,DDI=0,DDA=CENTER,DDS=Line 3,DDID=3},{DDBC=WHITE,DDTC=BLACK,DDI=0,DDA=CENTER,DDS=Line 4,DDID=4,DDC=true}'
  address: 002A5A49C0FFEE
  channel: 3
  param: COMBINED_PARAMETER
  interface: ip
```
WARNING: value MUST NOT contain spaces between items or linebreaks.

DDI
 1 = Lampe aus
 2 = Lampe ein
 3 = Schloss auf
 0 = Nicht benutzt
 4 = Schloss zu
 5 = X 
 6 = Häckchen
 7 = Info
 8 = Briefumschlag
 9 = Schraubenschlüssel
 10 = Sonne
 11 = Mond
 12 = Wind
 13 = Wolke
 14 = Wolke/Blitz
 15 = Wolke/leichter Regen
 16 = Wolke/Mond
 17 = Wolke/Regen
 18 = Wolke/Schnee
 19 = Wolke/Sonne
 20 = Wolke/Sonne/Regen
 21 = Wolke/Schneeflocke
 22 = Wolke/Regentropfen
 23 = Flamme
 24 = Fenster auf
 25 = Rollladen
 26 = Eco
 27 = Unscharf
 28 = Hüllschutz
 29 = Vollschutz
 30 = Benachrichtigung
 31 = Uhr

ANS sound list
-1 = Nicht benutzt
0 = Batterie leer, kurz-kurz-kurz
1 = Alarm aus,  lang-kurz
2 = Externer Alarm aktiviert, lang-kurz-kurz
3 = Interner Alarm aktiviert, lang-kurz
4 = Externer Alarm verzögert aktiviert, kurz-kurz
5 = Interner Alarm verzögert aktiviert, kurz
7 = Fehler, lang
6 = Event, mittel

[source for values](https://homematic-forum.de/forum/viewtopic.php?t=55269), can also be extracted from CCU WebUI
