### PR TITLE
Add support for the HmIP-SWDO-PL shutter contact

### DIFF
--- a/pyhomematic/devicetypes/sensors.py
+++ b/pyhomematic/devicetypes/sensors.py
@@ -935,6 +935,7 @@ DEVICETYPES = {
     "HmIP-SCI": IPShutterContactSabotage,
     "HMIP-SWDO": IPShutterContactSabotage,
     "HmIP-SWDO": IPShutterContactSabotage,
+    "HmIP-SWDO-PL": IPShutterContactSabotage,
     "HmIP-SWDO-I": IPShutterContactSabotage,
     "HmIP-SWDM": IPShutterContact,
     "HmIP-SWDM-B2": IPShutterContact,


### PR DESCRIPTION
The "PL" is just the big brother of the HmIP-SWDO with 2 batteries instead of one, so you don't have to change them as often.
