### PR TITLE
Add support for the HmIP-DSD-PCB doorbell signal detection sensor

### DIFF
--- a/pyhomematic/devicetypes/sensors.py
+++ b/pyhomematic/devicetypes/sensors.py
@@ -52,6 +52,7 @@ class SensorHmIP(HMSensor, HelperRssiDevice, HelperLowBatIP, HelperOperatingVolt
          - low battery status (HelperLowBatIP)
          - voltage of the batteries (HelperOperatingVoltageIP)"""
 
+
 class SensorHmIPNoVoltage(HMSensor, HelperRssiDevice, HelperLowBatIP):
     """Some Homematic IP sensors have
          - strength of the signal received by the CCU (HelperRssiDevice).
@@ -62,6 +63,7 @@ class SensorHmIPNoVoltage(HMSensor, HelperRssiDevice, HelperLowBatIP):
            and DEVICE compared to standard HM devices.
          - low battery status (HelperLowBatIP)
          - but no voltage of batteries"""
+
 
 class SensorHmIPNoBattery(HMSensor, HelperRssiDevice):
     """Some Homematic IP sensors have
@@ -921,7 +923,7 @@ class IPContact(SensorHmIP, HelperBinaryState, HelperEventRemote):
             return [1, 2, 3, 4, 5, 6]
         elif "FCI1" in self._TYPE:
             return [1]
-
+        return [1]
 
 
 DEVICETYPES = {
@@ -1019,5 +1021,6 @@ DEVICETYPES = {
     "HB-UNI-Sensor1": UniversalSensor,
     "HmIP-FCI1": IPContact,
     "HmIP-FCI6": IPContact,
+    "HmIP-DSD-PCB": IPContact,
     "HB-UNI-Sen-TEMP-DS18B20": TemperatureSensor,
 }


### PR DESCRIPTION
This pull request:
- adds support for HomeMatic device: HmIP-DSD-PCB Doorbell signal detection
