### PR TITLE
0.1.67

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+Version 0.1.67 (2020-)
+- 
+
 Version 0.1.66 (2020-04-17)
 - Add support for HmIP-DRSI4 @danielperna84
 - Add support for HmIP-PMFS @k-laus

--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@ Version 0.1.67 (2020-)
 - Add support for HmIP-SWDO-PL @rgriebl
 - Add buttons for HmIP-SMI55 @angelnu
 - Add support for HmIP-DSD-PCB @Ahrak
+- Add support for HmIPW-DRS4, HmIPW-DRS8, HmIPW-DRI32, HmIPW-DRI16 @henningweiler
 
 Version 0.1.66 (2020-04-17)
 - Add support for HmIP-DRSI4 @danielperna84

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,5 @@
 Version 0.1.67 (2020-)
-- 
+- Refactoring @danielperna84
 
 Version 0.1.66 (2020-04-17)
 - Add support for HmIP-DRSI4 @danielperna84

--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@ Version 0.1.67 (2020-)
 - Add buttons for HmIP-SMI55 @angelnu
 - Add support for HmIP-DSD-PCB @Ahrak
 - Add support for HmIPW-DRS4, HmIPW-DRS8, HmIPW-DRI32, HmIPW-DRI16 @henningweiler
+- Add support for HmIP-DBB, HB-UNI-Sen-WEA @danielperna84
 
 Version 0.1.66 (2020-04-17)
 - Add support for HmIP-DRSI4 @danielperna84

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@ Version 0.1.67 (2020-)
 - Refactoring @danielperna84
 - Add support for HmIP-SWDO-PL @rgriebl
 - Add buttons for HmIP-SMI55 @angelnu
+- Add support for HmIP-DSD-PCB @Ahrak
 
 Version 0.1.66 (2020-04-17)
 - Add support for HmIP-DRSI4 @danielperna84

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,7 @@
 Version 0.1.67 (2020-)
 - Refactoring @danielperna84
+- Add support for HmIP-SWDO-PL @rgriebl
+- Add buttons for HmIP-SMI55 @angelnu
 
 Version 0.1.66 (2020-04-17)
 - Add support for HmIP-DRSI4 @danielperna84

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,4 @@
-Version 0.1.67 (2020-)
+Version 0.1.67 (2020-05-14)
 - Refactoring @danielperna84
 - Add support for HmIP-SWDO-PL @rgriebl
 - Add buttons for HmIP-SMI55 @angelnu

--- a/pyhomematic/_hm.py
+++ b/pyhomematic/_hm.py
@@ -9,7 +9,9 @@ from xmlrpc.server import SimpleXMLRPCServer
 from xmlrpc.server import SimpleXMLRPCRequestHandler
 import xmlrpc.client
 import socket
+from socketserver import ThreadingMixIn
 import logging
+
 from pyhomematic import devicetypes
 from pyhomematic.devicetypes.generic import HMChannel
 
@@ -576,7 +578,6 @@ class ServerThread(threading.Thread):
 
         # Setup server to handle requests from CCU / Homegear
         LOG.debug("ServerThread.__init__: Setting up server")
-        from socketserver import ThreadingMixIn
         class SimpleThreadedXMLRPCServer(ThreadingMixIn, SimpleXMLRPCServer):
             pass
         self.server = SimpleThreadedXMLRPCServer((self._local, self._localport),

--- a/pyhomematic/_hm.py
+++ b/pyhomematic/_hm.py
@@ -9,7 +9,7 @@ from xmlrpc.server import SimpleXMLRPCServer
 from xmlrpc.server import SimpleXMLRPCRequestHandler
 import xmlrpc.client
 import socket
-from socketserver import ThreadingMixIn
+#from socketserver import ThreadingMixIn
 import logging
 
 from pyhomematic import devicetypes
@@ -578,11 +578,14 @@ class ServerThread(threading.Thread):
 
         # Setup server to handle requests from CCU / Homegear
         LOG.debug("ServerThread.__init__: Setting up server")
-        class SimpleThreadedXMLRPCServer(ThreadingMixIn, SimpleXMLRPCServer):
-            pass
-        self.server = SimpleThreadedXMLRPCServer((self._local, self._localport),
-                                                 requestHandler=RequestHandler,
-                                                 logRequests=False)
+        # class SimpleThreadedXMLRPCServer(ThreadingMixIn, SimpleXMLRPCServer):
+        #     pass
+        # self.server = SimpleThreadedXMLRPCServer((self._local, self._localport),
+        #                                          requestHandler=RequestHandler,
+        #                                          logRequests=False)
+        self.server = SimpleXMLRPCServer((self._local, self._localport),
+                                         requestHandler=RequestHandler,
+                                         logRequests=False)
         self._localport = self.server.socket.getsockname()[1]
         self.server.register_introspection_functions()
         self.server.register_multicall_functions()

--- a/pyhomematic/_hm.py
+++ b/pyhomematic/_hm.py
@@ -561,8 +561,39 @@ class ServerThread(threading.Thread):
         self.proxies = {}
         self.failed_inits = []
 
-        # Create proxies to interact with CCU / Homegear
-        LOG.debug("__init__: Creating proxies")
+        self.createProxies()
+        if not self.proxies:
+            LOG.warning("No proxies available. Aborting.")
+            raise Exception
+
+        self._rpcfunctions = RPCFunctions(devicefile=self._devicefile,
+                                          paramsetfile=self._paramsetfile,
+                                          proxies=self.proxies,
+                                          remotes=self.remotes,
+                                          eventcallback=self.eventcallback,
+                                          systemcallback=self.systemcallback,
+                                          resolveparamsets=self.resolveparamsets)
+
+        # Setup server to handle requests from CCU / Homegear
+        LOG.debug("ServerThread.__init__: Setting up server")
+        self.server = SimpleXMLRPCServer((self._local, self._localport),
+                                         requestHandler=RequestHandler,
+                                         logRequests=False)
+        self._localport = self.server.socket.getsockname()[1]
+        self.server.register_introspection_functions()
+        self.server.register_multicall_functions()
+        LOG.debug("ServerThread.__init__: Registering RPC functions")
+        self.server.register_instance(
+            self._rpcfunctions, allow_dotted_names=True)
+
+    def run(self):
+        LOG.info("Starting server at http://%s:%i" %
+                 (self._local, self._localport))
+        self.server.serve_forever()
+
+    def createProxies(self):
+        """Create proxies to interact with CCU / Homegear"""
+        LOG.debug("createProxies: Creating proxies")
         for remote, host in self.remotes.items():
             # Initialize XML-RPC
             try:
@@ -607,34 +638,10 @@ class ServerThread(threading.Thread):
                 LOG.warning("__init__: Failed to detect backend type: %s" % str(err))
                 host['type'] = BACKEND_UNKNOWN
 
-        if not self.proxies:
-            LOG.warning("No proxies available. Aborting.")
-            raise Exception
-
-        self._rpcfunctions = RPCFunctions(devicefile=self._devicefile,
-                                          paramsetfile=self._paramsetfile,
-                                          proxies=self.proxies,
-                                          remotes=self.remotes,
-                                          eventcallback=self.eventcallback,
-                                          systemcallback=self.systemcallback,
-                                          resolveparamsets=self.resolveparamsets)
-
-        # Setup server to handle requests from CCU / Homegear
-        LOG.debug("ServerThread.__init__: Setting up server")
-        self.server = SimpleXMLRPCServer((self._local, self._localport),
-                                         requestHandler=RequestHandler,
-                                         logRequests=False)
-        self._localport = self.server.socket.getsockname()[1]
-        self.server.register_introspection_functions()
-        self.server.register_multicall_functions()
-        LOG.debug("ServerThread.__init__: Registering RPC functions")
-        self.server.register_instance(
-            self._rpcfunctions, allow_dotted_names=True)
-
-    def run(self):
-        LOG.info("Starting server at http://%s:%i" %
-                 (self._local, self._localport))
-        self.server.serve_forever()
+    def clearProxies(self):
+        """Remove existing proxy objects."""
+        LOG.debug("clearProxies: Clearing proxies")
+        self.proxies.clear()
 
     def proxyInit(self):
         """
@@ -644,6 +651,7 @@ class ServerThread(threading.Thread):
         # the receiver) to receive events. XML RPC server has to be running.
         for interface_id, proxy in self.proxies.items():
             if proxy._skipinit:
+                LOG.warning("Skipping init for %s", interface_id)
                 continue
             if proxy._callbackip and proxy._callbackport:
                 callbackip = proxy._callbackip
@@ -656,18 +664,18 @@ class ServerThread(threading.Thread):
             try:
                 proxy.init("http://%s:%i" %
                            (callbackip, callbackport), interface_id)
-                LOG.info("Proxy initialized")
+                LOG.info("Proxy for %s initialized", interface_id)
             except Exception as err:
                 LOG.debug("proxyInit: Exception: %s" % str(err))
-                LOG.warning("Failed to initialize proxy")
+                LOG.warning("Failed to initialize proxy for %s", interface_id)
                 self.failed_inits.append(interface_id)
 
-    def stop(self):
-        """To stop the server we de-init from the CCU / Homegear, then shut down our XML-RPC server."""
+    def proxyDeInit(self):
+        """De-Init from the proxies."""
         stopped = []
         for interface_id, proxy in self.proxies.items():
             if interface_id in self.failed_inits:
-                LOG.warning("ServerThread.stop: Not performing de-init for %s" % interface_id)
+                LOG.warning("ServerThread.proxyDeInit: Not performing de-init for %s", interface_id)
                 continue
             if proxy._callbackip and proxy._callbackport:
                 callbackip = proxy._callbackip
@@ -676,21 +684,25 @@ class ServerThread(threading.Thread):
                 callbackip = proxy._localip
                 callbackport = self._localport
             remote = "http://%s:%i" % (callbackip, callbackport)
-            LOG.debug("ServerThread.stop: init('%s')" % remote)
-            if not callbackip in stopped:
+            LOG.debug("ServerThread.proxyDeInit: init('%s')", remote)
+            if not interface_id in stopped:
                 try:
                     proxy.init(remote)
-                    stopped.append(callbackip)
-                    LOG.info("Proxy de-initialized: %s" % remote)
+                    stopped.append(interface_id)
+                    LOG.info("proxyDeInit: Proxy for %s de-initialized: %s", interface_id, remote)
                 except Exception as err:
-                    LOG.debug("proxyInit: Exception: %s" % str(err))
-                    LOG.warning("Failed to de-initialize proxy")
-        self.proxies.clear()
+                    LOG.debug("proxyDeInit: Exception: %s", err)
+                    LOG.warning("proxyDeInit: Failed to de-initialize proxy")
+
+    def stop(self):
+        """To stop the server we de-init from the CCU / Homegear, then shut down our XML-RPC server."""
+        self.proxyDeInit()
+        self.clearProxies()
         LOG.info("Shutting down server")
         self.server.shutdown()
         LOG.debug("ServerThread.stop: Stopping ServerThread")
         self.server.server_close()
-        LOG.info("Server stopped")
+        LOG.info("HomeMatic XML-RPC Server stopped")
 
     def parseCCUSysVar(self, data):
         """Helper to parse type of system variables of CCU"""

--- a/pyhomematic/devicetypes/actors.py
+++ b/pyhomematic/devicetypes/actors.py
@@ -133,7 +133,7 @@ class Dimmer(GenericDimmer, HelperWorking):
     """
     @property
     def ELEMENT(self):
-        if "Dim2L" in self._TYPE or "Dim2T" in self._TYPE  or self._TYPE == "HM-DW-WM" or self._TYPE == "HM-LC-DW-WM":
+        if "Dim2L" in self._TYPE or "Dim2T" in self._TYPE  or self._TYPE == "HM-DW-WM":
             return [1, 2]
         return [1]
 

--- a/pyhomematic/devicetypes/actors.py
+++ b/pyhomematic/devicetypes/actors.py
@@ -584,7 +584,7 @@ class IPKeySwitchPowermeter(IPSwitchPowermeter, HMEvent, HelperActionPress):
                                "PRESS_LONG": [1, 2]})
 
 
-class IPGarage(GenericSwitch, HMSensor):
+class IPGarage(GenericSwitch, GenericBlind, HMSensor):
     """
     HmIP-MOD-HO and HmIP-MOD-TM Garage actor
     """
@@ -594,16 +594,33 @@ class IPGarage(GenericSwitch, HMSensor):
         # init metadata
         self.SENSORNODE.update({"DOOR_STATE": [1]})
 
-    def move_up(self):
+    def is_closed(self, state):
+        """Returns whether the door is closed"""
+        # States:
+        # 0: closed
+        # 1: open
+        # 2: ventilation
+        # 3: unknown
+        if state in [2, 3]:
+            return None
+        return state == 0
+
+    def move_up(self, channel=1):
         """Opens the garage"""
+        # channel needs to be hardcoded to "1"; home assistant somehow calls the cover entity with channel=2
+        # and then the command does not work.
         return self.setValue("DOOR_COMMAND", 1, channel=1)
 
-    def stop(self):
+    def stop(self, channel=1):
         """Stop motion"""
+        # channel needs to be hardcoded to "1"; home assistant somehow calls the cover entity with channel=2
+        # and then the command does not work.
         return self.setValue("DOOR_COMMAND", 2, channel=1)
 
-    def move_down(self):
+    def move_down(self, channel=1):
         """Close the garage"""
+        # channel needs to be hardcoded to "1"; home assistant somehow calls the cover entity with channel=2
+        # and then the command does not work.
         return self.setValue("DOOR_COMMAND", 3, channel=1)
 
     def vent(self):

--- a/pyhomematic/devicetypes/helper.py
+++ b/pyhomematic/devicetypes/helper.py
@@ -279,3 +279,14 @@ class HelperRssiPeer(HMDevice):
 
     def get_rssi(self, channel=0):
         return self.getAttributeData("RSSI_PEER", channel)
+
+
+class HelperDeviceTemperature(HMDevice):
+    """Used for devices that report their actual device temperature values (such as the HmIP Wired devices)"""
+
+    def __init__(self, device_description, proxy, resolveparamsets=False):
+        super().__init__(device_description, proxy, resolveparamsets)
+        self.ATTRIBUTENODE["ACTUAL_TEMPERATURE"] = [0]
+
+    def get_device_temperature(self, channel=0):
+        return self.getAttributeData("ACTUAL_TEMPERATURE", channel)

--- a/pyhomematic/devicetypes/misc.py
+++ b/pyhomematic/devicetypes/misc.py
@@ -150,4 +150,5 @@ DEVICETYPES = {
     "HMW-RCV-50": RemoteVirtual,
     "HmIP-RCV-50": RemoteVirtual,
     "HmIP-RC8": Remote,
+    "HmIP-DBB": RemoteBatteryIP,
 }

--- a/pyhomematic/devicetypes/sensors.py
+++ b/pyhomematic/devicetypes/sensors.py
@@ -511,6 +511,7 @@ class IPRemoteMotionV2(Remote, MotionIPV2):
     """Motion detection with buttons (hm ip).
        This is a binary sensor."""
 
+    # pylint: disable=useless-super-delegation
     def __init__(self, device_description, proxy, resolveparamsets=False):
         super().__init__(device_description, proxy, resolveparamsets)
 

--- a/pyhomematic/devicetypes/sensors.py
+++ b/pyhomematic/devicetypes/sensors.py
@@ -52,6 +52,7 @@ class SensorHmIP(HMSensor, HelperRssiDevice, HelperLowBatIP, HelperOperatingVolt
          - low battery status (HelperLowBatIP)
          - voltage of the batteries (HelperOperatingVoltageIP)"""
 
+
 class SensorHmIPNoVoltage(HMSensor, HelperRssiDevice, HelperLowBatIP):
     """Some Homematic IP sensors have
          - strength of the signal received by the CCU (HelperRssiDevice).
@@ -62,6 +63,7 @@ class SensorHmIPNoVoltage(HMSensor, HelperRssiDevice, HelperLowBatIP):
            and DEVICE compared to standard HM devices.
          - low battery status (HelperLowBatIP)
          - but no voltage of batteries"""
+
 
 class SensorHmIPNoBattery(HMSensor, HelperRssiDevice):
     """Some Homematic IP sensors have
@@ -928,7 +930,7 @@ class IPContact(SensorHmIP, HelperBinaryState, HelperEventRemote):
             return [1, 2, 3, 4, 5, 6]
         elif "FCI1" in self._TYPE:
             return [1]
-
+        return [1]
 
 
 DEVICETYPES = {
@@ -1027,5 +1029,6 @@ DEVICETYPES = {
     "HB-UNI-Sensor1": UniversalSensor,
     "HmIP-FCI1": IPContact,
     "HmIP-FCI6": IPContact,
+    "HmIP-DSD-PCB": IPContact,
     "HB-UNI-Sen-TEMP-DS18B20": TemperatureSensor,
 }

--- a/pyhomematic/devicetypes/sensors.py
+++ b/pyhomematic/devicetypes/sensors.py
@@ -606,6 +606,24 @@ class TemperatureSensor(SensorHm):
         return float(self.getSensorData("TEMPERATURE", channel))
 
 
+class HBUNISenWEA(TemperatureSensor):
+    """HB-UNI-Sen-WEA"""
+    def __init__(self, device_description, proxy, resolveparamsets=False):
+        super().__init__(device_description, proxy, resolveparamsets)
+
+        self.SENSORNODE.update({"AIR_PRESSURE": self.ELEMENT,
+                                "HUMIDITY": self.ELEMENT,
+                                "LUX": self.ELEMENT,
+                                "RAIN_COUNTER": self.ELEMENT,
+                                "WIND_SPEED": self.ELEMENT,
+                                "WIND_DIRECTION": self.ELEMENT,
+                                "WIND_DIRECTION_RANGE": self.ELEMENT,
+                                "GUST_SPEED": self.ELEMENT,
+                                "UVINDEX": self.ELEMENT,
+                                "LIGHTNING_COUNTER": self.ELEMENT,
+                                "LIGHNTING_DISTANCE": self.ELEMENT})
+
+
 class TemperatureDiffSensor(SensorHm):
     """Temperature difference Sensor."""
 
@@ -1032,4 +1050,5 @@ DEVICETYPES = {
     "HmIP-FCI6": IPContact,
     "HmIP-DSD-PCB": IPContact,
     "HB-UNI-Sen-TEMP-DS18B20": TemperatureSensor,
+    "HB-UNI-Sen-WEA": HBUNISenWEA,
 }

--- a/pylintrc
+++ b/pylintrc
@@ -32,3 +32,4 @@ disable=
   not-context-manager,
   inconsistent-return-statements,
   duplicate-code,
+  too-many-lines,

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ def readme():
 
 PACKAGE_NAME = 'pyhomematic'
 HERE = os.path.abspath(os.path.dirname(__file__))
-VERSION = '0.1.66'
+VERSION = '0.1.67'
 
 PACKAGES = find_packages(exclude=['tests', 'tests.*', 'dist', 'build'])
 


### PR DESCRIPTION
Version 0.1.67

This pull request:
- Some refactoring
- adds support for HomeMatic devices: HmIP-SWDO-P, HmIP-SMI55, HmIP-DSD-PCB, HmIPW-DRS4, HmIPW-DRS8, HmIPW-DRI32, HmIPW-DRI16, HmIP-DBB, HB-UNI-Sen-WEA
  - New classes: MotionIPV2, IPRemoteMotionV2, IPWSwitch, IPWInputDevice, HBUNISenWEA
- Improve support for HmIP-MOD-HO, HmIP-MOD-TM

What needs to be done in HA:
#### In binary_sensor.py add
```python
    "MotionIPV2": DEVICE_CLASS_MOTION,
    "IPRemoteMotionV2": DEVICE_CLASS_MOTION,
```

#### In const.py add
```python
# DISCOVER_SWITCHES
        "IPWSwitch",
# DISCOVER_SENSORS
        "IPRemoteMotionV2",
        "HBUNISenWEA",
...
# DISCOVER_BINARY_SENSORS
        "IPRemoteMotionV2",
        "IPWInputDevice",
```