### PR TITLE
Do not report two dimmers for HM-LC-DW-WM

### DIFF
--- a/pyhomematic/devicetypes/actors.py
+++ b/pyhomematic/devicetypes/actors.py
@@ -133,7 +133,7 @@ class Dimmer(GenericDimmer, HelperWorking):
     """
     @property
     def ELEMENT(self):
-        if "Dim2L" in self._TYPE or "Dim2T" in self._TYPE  or self._TYPE == "HM-DW-WM" or self._TYPE == "HM-LC-DW-WM":
+        if "Dim2L" in self._TYPE or "Dim2T" in self._TYPE  or self._TYPE == "HM-DW-WM":
             return [1, 2]
         return [1]
 


### PR DESCRIPTION
This pull request:
- fixes issue: #280 
- does the following: Avoids reporting two dimmers when controller uses second channel to control temperature and not and independent led.
