### PR TITLE
Improve support for homematic IP garage covers

### DIFF
--- a/pyhomematic/devicetypes/actors.py
+++ b/pyhomematic/devicetypes/actors.py
@@ -594,9 +594,8 @@ class IPGarage(GenericSwitch, GenericBlind, HMSensor):
         # init metadata
         self.SENSORNODE.update({"DOOR_STATE": [1]})
 
-    def is_closed(self):
+    def is_closed(self, state):
         """Returns whether the door is closed"""
-        state = self.getValue("DOOR_STATE", channel=1)
         # States:
         # 0: closed
         # 1: open
@@ -606,15 +605,15 @@ class IPGarage(GenericSwitch, GenericBlind, HMSensor):
             return None
         return state == 0
 
-    def move_up(self, channel=1):
+    def move_up(self, _=None):
         """Opens the garage"""
         return self.setValue("DOOR_COMMAND", 1, channel=1)
 
-    def stop(self, channel=1):
+    def stop(self, _=None):
         """Stop motion"""
         return self.setValue("DOOR_COMMAND", 2, channel=1)
 
-    def move_down(self, channel=1):
+    def move_down(self, _=None):
         """Close the garage"""
         return self.setValue("DOOR_COMMAND", 3, channel=1)
 

--- a/pyhomematic/devicetypes/actors.py
+++ b/pyhomematic/devicetypes/actors.py
@@ -605,16 +605,22 @@ class IPGarage(GenericSwitch, GenericBlind, HMSensor):
             return None
         return state == 0
 
-    def move_up(self, _=None):
+    def move_up(self, channel=1):
         """Opens the garage"""
+        # channel needs to be hardcoded to "1"; home assistant somehow calls the cover entity with channel=2
+        # and then the command does not work.
         return self.setValue("DOOR_COMMAND", 1, channel=1)
 
-    def stop(self, _=None):
+    def stop(self, channel=1):
         """Stop motion"""
+        # channel needs to be hardcoded to "1"; home assistant somehow calls the cover entity with channel=2
+        # and then the command does not work.
         return self.setValue("DOOR_COMMAND", 2, channel=1)
 
-    def move_down(self, _=None):
+    def move_down(self, channel=1):
         """Close the garage"""
+        # channel needs to be hardcoded to "1"; home assistant somehow calls the cover entity with channel=2
+        # and then the command does not work.
         return self.setValue("DOOR_COMMAND", 3, channel=1)
 
     def vent(self):

--- a/pyhomematic/devicetypes/actors.py
+++ b/pyhomematic/devicetypes/actors.py
@@ -584,7 +584,7 @@ class IPKeySwitchPowermeter(IPSwitchPowermeter, HMEvent, HelperActionPress):
                                "PRESS_LONG": [1, 2]})
 
 
-class IPGarage(GenericSwitch, HMSensor):
+class IPGarage(GenericSwitch, GenericBlind, HMSensor):
     """
     HmIP-MOD-HO and HmIP-MOD-TM Garage actor
     """
@@ -594,15 +594,27 @@ class IPGarage(GenericSwitch, HMSensor):
         # init metadata
         self.SENSORNODE.update({"DOOR_STATE": [1]})
 
-    def move_up(self):
+    def is_closed(self):
+        """Returns whether the door is closed"""
+        state = self.getValue("DOOR_STATE", channel=1)
+        # States:
+        # 0: closed
+        # 1: open
+        # 2: ventilation
+        # 3: unknown
+        if state in [2, 3]:
+            return None
+        return state == 0
+
+    def move_up(self, channel=1):
         """Opens the garage"""
         return self.setValue("DOOR_COMMAND", 1, channel=1)
 
-    def stop(self):
+    def stop(self, channel=1):
         """Stop motion"""
         return self.setValue("DOOR_COMMAND", 2, channel=1)
 
-    def move_down(self):
+    def move_down(self, channel=1):
         """Close the garage"""
         return self.setValue("DOOR_COMMAND", 3, channel=1)
 


### PR DESCRIPTION
Those changes are required to be able to add a cover entity in home assistant for the garage door controlers HmIP-MOD-HO and HmIP-MOD-TM.

This pull request:
- fixes issue: https://github.com/home-assistant/core/issues/35270
- improves support for HomeMatic device: HmIP-MOD-HO, HmIP-MOD-TM
  - New class: \<e.g. YourSensor>
  - Home Assistant [platform](https://github.com/home-assistant/home-assistant/blob/0da3e737651a150c17016f43b5f9144deff7ddd7/homeassistant/components/homematic/__init__.py#L65): \<e.g. `DISCOVER_COVER`>
- does the following:
  - Adds a required channel parameter to the IPGarage control methods (move_up, stop, move_down).
  - Adds a method to check whether the cover is closed.
 - is related to a PR in home-assistant: https://github.com/home-assistant/core/pull/35350

