### PR TITLE
Feature/hb uni rgb led ctrl

### DIFF
--- a/pyhomematic/devicetypes/actors.py
+++ b/pyhomematic/devicetypes/actors.py
@@ -1038,4 +1038,5 @@ DEVICETYPES = {
     "HmIP-MIOB": IPMultiIO,
     "HM-DW-WM": Dimmer,
     "HM-LC-DW-WM": ColdWarmDimmer,
+    "HB-UNI-RGB-LED-CTRL": ColorEffectLight,
 }


### PR DESCRIPTION
This pull request:
- adds support for HomeMatic device: HB-UNI-RGB-LED-CTRL

tested with latest version of the sketch/JB-HB-Devices-Addon and the provided VM
