### PR TITLE
0.1.68

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,10 @@
+Version 0.1.68 (2020-08-04)
+- Support rx_mode @rusitschka
+- HomeMatic IP stability @weissm
+- Add Sensor-Node for HmIP-Covers @danielperna84
+- Add support for HmIPW devices @p0l0
+- Add support for HB-UNI-RGB-LED-CTR @lukasriegel
+
 Version 0.1.67 (2020-05-14)
 - Refactoring @danielperna84
 - Add support for HmIP-SWDO-PL @rgriebl

--- a/pyhomematic/_hm.py
+++ b/pyhomematic/_hm.py
@@ -982,9 +982,13 @@ class ServerThread(threading.Thread):
                 "ServerThread.homegearCheckInit: Exception: %s" % str(err))
             return False
 
-    def putParamset(self, remote, address, paramset, value):
+    def putParamset(self, remote, address, paramset, value, rx_mode=None):
         """Set paramsets manually"""
         try:
-            return self.proxies["%s-%s" % (self._interface_id, remote)].putParamset(address, paramset, value)
+            proxy = self.proxies["%s-%s" % (self._interface_id, remote)]
+            if rx_mode is None:
+                return proxy.putParamset(address, paramset, value)
+            else:
+                return proxy.putParamset(address, paramset, value, rx_mode)
         except Exception as err:
             LOG.debug("ServerThread.putParamset: Exception: %s" % str(err))

--- a/pyhomematic/_hm.py
+++ b/pyhomematic/_hm.py
@@ -366,7 +366,10 @@ class RPCFunctions():
 
             headers = {"Content-Type": 'application/json',
                        "Content-Length": len(payload)}
-            apiendpoint = "http://%s:%s%s" % (host, jsonport, JSONRPC_URL)
+            if jsonport == 443:
+                apiendpoint = "https://%s:%s%s" % (host, jsonport, JSONRPC_URL)
+            else:
+                apiendpoint = "http://%s:%s%s" % (host, jsonport, JSONRPC_URL)
             LOG.debug("RPCFunctions.jsonRpcPost: API-Endpoint: %s" %
                       apiendpoint)
             req = urllib.request.Request(apiendpoint, payload, headers)

--- a/pyhomematic/connection.py
+++ b/pyhomematic/connection.py
@@ -189,7 +189,7 @@ class HMConnection():
         if self._server is not None:
             return self._server.homegearCheckInit(remote)
 
-    def putParamset(self, remote, address, paramset, value):
+    def putParamset(self, remote, address, paramset, value, rx_mode=None):
         """Set paramsets manually"""
         if self._server is not None:
-            return self._server.putParamset(remote, address, paramset, value)
+            return self._server.putParamset(remote, address, paramset, value, rx_mode)

--- a/pyhomematic/devicetypes/actors.py
+++ b/pyhomematic/devicetypes/actors.py
@@ -57,6 +57,7 @@ class IPBlind(GenericBlind, HelperRssiPeer):
                                    "LEVEL_STATUS": self.ELEMENT,
                                    "SECTION": self.ELEMENT})
         self.ACTIONNODE.update({"STOP": self.ELEMENT})
+        self.SENSORNODE.update({"LEVEL": [3]})
         self.WRITENODE.update({"LEVEL": self.ELEMENT})
 
 

--- a/pyhomematic/devicetypes/actors.py
+++ b/pyhomematic/devicetypes/actors.py
@@ -1038,4 +1038,5 @@ DEVICETYPES = {
     "HmIP-MIOB": IPMultiIO,
     "HM-DW-WM": Dimmer,
     "HM-LC-DW-WM": ColdWarmDimmer,
+    "HB-UNI-RGB-LED-CTRL": ColorEffectLight,
 }

--- a/pyhomematic/devicetypes/actors.py
+++ b/pyhomematic/devicetypes/actors.py
@@ -326,7 +326,7 @@ class HMWIOSwitch(GenericSwitch, HelperWired):
 
 class IPWSwitch(GenericSwitch, HelperDeviceTemperature, HelperWired):
     """
-    HomematicIP-Wired Switch units turning attached device on or off.
+    IP-Wired Switch units turning attached device on or off.
     """
     @property
     def ELEMENT(self):
@@ -338,6 +338,56 @@ class IPWSwitch(GenericSwitch, HelperDeviceTemperature, HelperWired):
             return [2, 6, 10, 14, 18, 22, 26, 30]
         return [1]
 
+
+class IPWDimmer(GenericDimmer, HelperDeviceTemperature, HelperWired):
+    """
+    IP-Wired Dimmer switch that controls level of light brightness.
+    """
+    @property
+    def ELEMENT(self):
+        if "HmIPW-DRD3" in self._TYPE:
+            # Address correct switching channels for each relais
+            return [2, 6, 10]
+        return [1]
+
+
+class IPWMotionDection(HelperWired):
+    """
+    IP-Wired Motion Detection
+    """
+    def __init__(self, device_description, proxy, resolveparamsets=False):
+        super().__init__(device_description, proxy, resolveparamsets)
+
+        # init metadata
+        self.BINARYNODE.update({"PRESENCE_DETECTION_STATE": self.ELEMENT,
+                                "PRESENCE_DETECTION_ACTIVE": self.ELEMENT,
+                                "CURRENT_ILLUMINATION_STATUS": self.ELEMENT,
+                                "ILLUMINATION_STATUS": self.ELEMENT})
+        self.SENSORNODE.update({"ILLUMINATION": self.ELEMENT,
+                                "CURRENT_ILLUMINATION": self.ELEMENT})
+
+    @property
+    def ELEMENT(self):
+        return [1]
+
+
+class IPWKeyBlindMulti(KeyBlind, HelperDeviceTemperature, HelperWired):
+    """
+    Multi-blind actor HmIPW-DRBL4
+    """
+    def __init__(self, device_description, proxy, resolveparamsets=False):
+        super().__init__(device_description, proxy, resolveparamsets)
+
+        # init metadata
+        self.ATTRIBUTENODE.update({"ACTIVITY_STATE": self.ELEMENT,
+                                   "LEVEL_STATUS": self.ELEMENT,
+                                   "SECTION": self.ELEMENT})
+        self.ACTIONNODE.update({"STOP": self.ELEMENT})
+        self.WRITENODE.update({"LEVEL": self.ELEMENT})
+
+    @property
+    def ELEMENT(self):
+        return [2, 6, 10, 14]
 
 class IPWInputDevice(HMEvent, HelperDeviceTemperature, HelperWired):
     """
@@ -947,6 +997,9 @@ DEVICETYPES = {
     "HmIPW-DRS8": IPWSwitch,
     "HmIPW-DRI32": IPWInputDevice,
     "HmIPW-DRI16": IPWInputDevice,
+    "HmIPW-DRD3": IPWDimmer,
+    "HmIPW-SPI": IPWMotionDection,
+    "HmIPW-DRBL4": IPWKeyBlindMulti,
     "HMIP-PS": IPSwitch,
     "HmIP-PS": IPSwitch,
     "HmIP-PS-CH": IPSwitch,

--- a/pyhomematic/devicetypes/generic.py
+++ b/pyhomematic/devicetypes/generic.py
@@ -107,7 +107,7 @@ class HMGeneric():
             LOG.error("HMGeneric.updateParamsets: Exception: " + str(err))
             return False
 
-    def putParamset(self, paramset, data={}):
+    def putParamset(self, paramset, data={}, rx_mode=None):
         """
         Some devices act upon changes to paramsets.
         A "putted" paramset must not contain all keys available in the specified paramset,
@@ -115,7 +115,10 @@ class HMGeneric():
         """
         try:
             if paramset in self._PARAMSETS and data:
-                self._proxy.putParamset(self._ADDRESS, paramset, data)
+                if rx_mode is None:
+                    self._proxy.putParamset(self._ADDRESS, paramset, data)
+                else:
+                    self._proxy.putParamset(self._ADDRESS, paramset, data, rx_mode)
                 # We update all paramsets to at least have a temporarily accurate state for the device.
                 # This might not be true for tasks that take long to complete (lifting a rollershutter completely etc.).
                 # For this the server-process has to call the updateParamsets-method when it receives events for the device.

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ def readme():
 
 PACKAGE_NAME = 'pyhomematic'
 HERE = os.path.abspath(os.path.dirname(__file__))
-VERSION = '0.1.67'
+VERSION = '0.1.68'
 
 PACKAGES = find_packages(exclude=['tests', 'tests.*', 'dist', 'build'])
 


### PR DESCRIPTION
This pull request:
- fixes issue: #299, #311 
- adds support for HomeMatic device: HB-UNI-RGB-LED-CTR, HmIPW-DRD3, HmIPW-SPI, HmIPW-DRBL4
  - New class: IPWDimmer
  - Home Assistant: DISCOVER_LIGHTS
  - IPWMotionDection
  - DISCOVER_SENSORS
  - IPWMotionDection
  - DISCOVER_BINARY_SENSORS
- does the following: Adds support for `rx_mode`. Returns empty lists on `listDevices` for HmIP.
