### PR TITLE
Changed IPWMotionDetection to Sensor and added support for HmIPW-FIO6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,13 @@ sudo: false
 matrix:
   fast_finish: true
   include:
-    - python: "3.4"
-      env: TOXENV=lint
-    - python: "3.5"
-      env: TOXENV=lint
-    - python: "3.5"
+    - python: "3.6"
       env: TOXENV=pyhomematic
     - python: "3.6"
+      env: TOXENV=lint
+    - python: "3.7"
+      env: TOXENV=lint
+    - python: "3.8"
       env: TOXENV=lint
 install: pip install -U tox
 language: python

--- a/pyhomematic/devicetypes/actors.py
+++ b/pyhomematic/devicetypes/actors.py
@@ -326,7 +326,7 @@ class HMWIOSwitch(GenericSwitch, HelperWired):
 
 class IPWSwitch(GenericSwitch, HelperDeviceTemperature, HelperWired):
     """
-    HomematicIP-Wired Switch units turning attached device on or off.
+    IP-Wired Switch units turning attached device on or off.
     """
     @property
     def ELEMENT(self):
@@ -338,6 +338,56 @@ class IPWSwitch(GenericSwitch, HelperDeviceTemperature, HelperWired):
             return [2, 6, 10, 14, 18, 22, 26, 30]
         return [1]
 
+
+class IPWDimmer(GenericDimmer, HelperDeviceTemperature, HelperWired):
+    """
+    IP-Wired Dimmer switch that controls level of light brightness.
+    """
+    @property
+    def ELEMENT(self):
+        if "HmIPW-DRD3" in self._TYPE:
+            # Address correct switching channels for each relais
+            return [2, 6, 10]
+        return [1]
+
+
+class IPWMotionDection(HelperWired):
+    """
+    IP-Wired Motion Detection
+    """
+    def __init__(self, device_description, proxy, resolveparamsets=False):
+       super().__init__(device_description, proxy, resolveparamsets)
+       
+       # init metadata
+       self.BINARYNODE.update({"PRESENCE_DETECTION_STATE": self.ELEMENT,
+                               "PRESENCE_DETECTION_ACTIVE": self.ELEMENT,
+                               "CURRENT_ILLUMINATION_STATUS": self.ELEMENT,
+                               "ILLUMINATION_STATUS": self.ELEMENT})
+       self.SENSORNODE.update({"ILLUMINATION": self.ELEMENT,
+                               "CURRENT_ILLUMINATION": self.ELEMENT})
+
+    @property
+    def ELEMENT(self):
+        return [1]
+
+
+class IPWKeyBlindMulti(KeyBlind, HelperDeviceTemperature, HelperWired):
+    """
+    Multi-blind actor HmIPW-DRBL4
+    """
+    def __init__(self, device_description, proxy, resolveparamsets=False):
+        super().__init__(device_description, proxy, resolveparamsets)
+
+        # init metadata
+        self.ATTRIBUTENODE.update({"ACTIVITY_STATE": self.ELEMENT,
+                                   "LEVEL_STATUS": self.ELEMENT,
+                                   "SECTION": self.ELEMENT})
+        self.ACTIONNODE.update({"STOP": self.ELEMENT})
+        self.WRITENODE.update({"LEVEL": self.ELEMENT})
+
+    @property
+    def ELEMENT(self):
+        return [2, 6, 10, 14]
 
 class IPWInputDevice(HMEvent, HelperDeviceTemperature, HelperWired):
     """
@@ -947,6 +997,9 @@ DEVICETYPES = {
     "HmIPW-DRS8": IPWSwitch,
     "HmIPW-DRI32": IPWInputDevice,
     "HmIPW-DRI16": IPWInputDevice,
+    "HmIPW-DRD3": IPWDimmer,
+    "HmIPW-SPI": IPWMotionDection,
+    "HmIPW-DRBL4": IPWKeyBlindMulti,
     "HMIP-PS": IPSwitch,
     "HmIP-PS": IPSwitch,
     "HmIP-PS-CH": IPSwitch,

--- a/pyhomematic/devicetypes/actors.py
+++ b/pyhomematic/devicetypes/actors.py
@@ -351,26 +351,6 @@ class IPWDimmer(GenericDimmer, HelperDeviceTemperature, HelperWired):
         return [1]
 
 
-class IPWMotionDection(HelperWired):
-    """
-    IP-Wired Motion Detection
-    """
-    def __init__(self, device_description, proxy, resolveparamsets=False):
-       super().__init__(device_description, proxy, resolveparamsets)
-       
-       # init metadata
-       self.BINARYNODE.update({"PRESENCE_DETECTION_STATE": self.ELEMENT,
-                               "PRESENCE_DETECTION_ACTIVE": self.ELEMENT,
-                               "CURRENT_ILLUMINATION_STATUS": self.ELEMENT,
-                               "ILLUMINATION_STATUS": self.ELEMENT})
-       self.SENSORNODE.update({"ILLUMINATION": self.ELEMENT,
-                               "CURRENT_ILLUMINATION": self.ELEMENT})
-
-    @property
-    def ELEMENT(self):
-        return [1]
-
-
 class IPWKeyBlindMulti(KeyBlind, HelperDeviceTemperature, HelperWired):
     """
     Multi-blind actor HmIPW-DRBL4
@@ -422,6 +402,42 @@ class IPWInputDevice(HMEvent, HelperDeviceTemperature, HelperWired):
             return [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]
         elif "HmIPW-DRI32" in self.TYPE:
             return [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32]
+        return [1]
+
+
+class IPWIODevice(HMEvent, GenericSwitch, HelperWired):
+    """
+    IP-Wired I/O component to support long / short press events and state report (e.g. if window contact or on/off switch)
+    """
+    def __init__(self, device_description, proxy, resolveparamsets=False):
+        super().__init__(device_description, proxy, resolveparamsets)
+        self._hmipw_keypress_event_channels = []
+        self._hmipw_binarysensor_channels = []
+        self._ic = [1]
+
+        # Set Input Channels depending on Device
+        if "HmIPW-FIO6" in self.TYPE:
+            self._ic = [1, 2, 3, 4, 5, 6]
+
+        # Get Operation Mode for Input Channels
+        for chan in self._ic:
+            try:
+                if self._proxy.getParamset("%s:%i" % (self._ADDRESS, chan), "MASTER").get("CHANNEL_OPERATION_MODE", None) == 1:
+                    self._hmipw_keypress_event_channels.append(chan)
+                else:
+                    self._hmipw_binarysensor_channels.append(chan)
+            except Exception as err:
+                LOG.error("IPWIODevice: Failure to determine input channel operations mode of HmIPW input device %s:%i %s", self._ADDRESS, chan, err)
+
+        self.ACTIONNODE.update({"PRESS_SHORT": self._hmipw_keypress_event_channels,
+                                "PRESS_LONG": self._hmipw_keypress_event_channels})
+        self.BINARYNODE.update({"STATE": self._hmipw_binarysensor_channels})
+
+    @property
+    def ELEMENT(self):
+        """ General output channel definition """
+        if "HmIPW-FIO6" in self.TYPE:
+            return [8, 12, 16, 20, 24, 28]
         return [1]
 
 
@@ -997,8 +1013,8 @@ DEVICETYPES = {
     "HmIPW-DRS8": IPWSwitch,
     "HmIPW-DRI32": IPWInputDevice,
     "HmIPW-DRI16": IPWInputDevice,
+    "HmIPW-FIO6": IPWIODevice,
     "HmIPW-DRD3": IPWDimmer,
-    "HmIPW-SPI": IPWMotionDection,
     "HmIPW-DRBL4": IPWKeyBlindMulti,
     "HMIP-PS": IPSwitch,
     "HmIP-PS": IPSwitch,

--- a/pyhomematic/devicetypes/sensors.py
+++ b/pyhomematic/devicetypes/sensors.py
@@ -53,6 +53,10 @@ class SensorHmIP(HMSensor, HelperRssiDevice, HelperLowBatIP, HelperOperatingVolt
          - voltage of the batteries (HelperOperatingVoltageIP)"""
 
 
+class SensorHmIPW(HMSensor, HelperWired):
+    """Homematic IP Wired sensors"""
+
+
 class SensorHmIPNoVoltage(HMSensor, HelperRssiDevice, HelperLowBatIP):
     """Some Homematic IP sensors have
          - strength of the signal received by the CCU (HelperRssiDevice).
@@ -461,6 +465,35 @@ class PresenceIP(SensorHmIP, HelperSabotageIP):
     @property
     def ELEMENT(self):
         return [0, 1]
+
+
+class PresenceIPW(SensorHmIPW):
+    """Presence detection with HmIPW-SPI.
+       This is a binary sensor."""
+
+    def __init__(self, device_description, proxy, resolveparamsets=False):
+        super().__init__(device_description, proxy, resolveparamsets)
+
+        # init metadata
+        self.BINARYNODE.update({"PRESENCE_DETECTION_STATE": self.ELEMENT,
+                                "PRESENCE_DETECTION_ACTIVE": self.ELEMENT,
+                                "CURRENT_ILLUMINATION_STATUS": self.ELEMENT,
+                                "ILLUMINATION_STATUS": self.ELEMENT})
+        self.SENSORNODE.update({"ILLUMINATION": self.ELEMENT,
+                                "CURRENT_ILLUMINATION": self.ELEMENT})
+        self.ATTRIBUTENODE.update({"ERROR_CODE": [0]})
+
+    def is_motion(self, channel=None):
+        """ Return True if motion is detected """
+        return bool(self.getBinaryData("PRESENCE_DETECTION_STATE", channel))
+
+    def get_brightness(self, channel=None):
+        """ Return brightness from 0 (dark) to 163830 (bright) """
+        return float(self.getSensorData("ILLUMINATION", channel))
+
+    @property
+    def ELEMENT(self):
+        return [1]
 
 
 class TiltIP(SensorHmIP):
@@ -997,6 +1030,7 @@ DEVICETYPES = {
     "HmIP-SMO": MotionIP,
     "HmIP-SMO-A": MotionIP,
     "HmIP-SPI": PresenceIP,
+    "HmIPW-SPI": PresenceIPW,
     "HM-Sen-LI-O": LuxSensor,
     "HM-Sen-EP": ImpulseSensor,
     "HM-Sen-X": ImpulseSensor,


### PR DESCRIPTION
Please point your pull request at the __devel__ branch. Also provide some information about the changes.

This pull request:
- contributes to discussion in issue: #219
- adds support for HomeMatic IP devices: "HmIPW-FIO6"
- changed _IPWMotionDetection_ from _Actor_ to _Sensor_ (New class: PresenceIPW)
- New classes: IPWIODevice

With today released CCU3 version 3.53.26 (https://www.homematic-ip.com/downloads/software/firmware/ccu3-firmware/CCU3-Changelog.3.53.26.pdf - [HMCCU-628]), FIO6, DRI16 and DRI32 should be working without "Generic Error"