### PR TITLE
added lowbat flag to the keylock device

### DIFF
--- a/pyhomematic/devicetypes/actors.py
+++ b/pyhomematic/devicetypes/actors.py
@@ -454,7 +454,8 @@ class KeyMatic(HMActor, HelperActorState, HelperRssiPeer):
         # init metadata
         self.ACTIONNODE.update({"OPEN": self.ELEMENT})
         self.ATTRIBUTENODE.update({"STATE_UNCERTAIN": self.ELEMENT,
-                                   "ERROR": self.ELEMENT})
+                                   "ERROR": self.ELEMENT, 
+                                   "LOWBAT": self.ELEMENT})
 
     def is_unlocked(self, channel=None):
         """ Returns True if KeyMatic is unlocked. """


### PR DESCRIPTION
there was no lowbat flag shown for the keylock device - seems it was forgotten within some code restructure

This pull request:
- adds the lowbat flag to the homematic keylock device

