### PR TITLE
Add Support for HmIP-ASIR

### DIFF
--- a/pyhomematic/devicetypes/sensors.py
+++ b/pyhomematic/devicetypes/sensors.py
@@ -951,6 +951,23 @@ class IPContact(SensorHmIP, HelperBinaryState, HelperEventRemote):
             return [1]
         return [1]
 
+class IPAlarmSensor(SensorHmIP, HelperSabotageIP):
+    """Alarm Sirene that emits its Acoustic and Optical Alarm Status"""
+
+    def __init__(self, device_description, proxy, resolveparamsets=False):
+        super().__init__(device_description, proxy, resolveparamsets)
+
+        # init metadata
+        self.BINARYNODE.update({
+            "OPTICAL_ALARM_ACTIVE": [3],
+            "ACOUSTIC_ALARM_ACTIVE": [3]
+        })
+
+    def is_optical_alarm_active(self, channel=None):
+        return bool(self.getBinaryData("OPTICAL_ALARM_ACTIVE", channel))
+        
+    def is_acoustic_alarm_active(self, channel=None):
+        return bool(self.getBinaryData("ACOUSTIC_ALARM_ACTIVE", channel))
 
 DEVICETYPES = {
     "HM-Sec-SC": ShutterContact,
@@ -1051,4 +1068,8 @@ DEVICETYPES = {
     "HmIP-DSD-PCB": IPContact,
     "HB-UNI-Sen-TEMP-DS18B20": TemperatureSensor,
     "HB-UNI-Sen-WEA": HBUNISenWEA,
+	"HmIP-ASIR-B1": IPAlarmSensor,
+	"HmIP-ASIR-O": IPAlarmSensor,
+	"HmIP-ASIR": IPAlarmSensor,
+	"HmIP-ASIR-2": IPAlarmSensor,
 }


### PR DESCRIPTION
This pull request:
- adds support for HomeMatic device: HmIP-ASIR
- New class: IPAlarmSensor
- Home Assistant [platform]: DISCOVER_BINARY_SENSORS
- does the following: Adds the Sensors: binary_sensor.XXX_low_bat, binary_sensor.XXX_optical_alarm_active, binary_sensor.XXX_acoustic_alarm_active. The last two indicate, if there is a active optical or acoustic alarm.

This was tested with HmIP-ASIR-B1, but I think, it should work with the other ASIR devices as well.

