### PR TITLE
Homeassistant/improve/cover

### DIFF
--- a/pyhomematic/_hm.py
+++ b/pyhomematic/_hm.py
@@ -455,7 +455,6 @@ class RPCFunctions():
                                     i['address']].NAME = i['name']
                                 for channel_device_response in i['channels']:
                                     name = channel_device_response['name']
-                                    channel_device = self.devices_all[remote][channel_device_response['address']]
                                     self.devices_all[remote][channel_device_response['address']].NAME = name
 
                         except Exception as err:

--- a/pyhomematic/_hm.py
+++ b/pyhomematic/_hm.py
@@ -453,6 +453,11 @@ class RPCFunctions():
                             if i.get('address') in self.devices[remote]:
                                 self.devices[remote][
                                     i['address']].NAME = i['name']
+                                for channel_device_response in i['channels']:
+                                    name = channel_device_response['name']
+                                    channel_device = self.devices_all[remote][channel_device_response['address']]
+                                    self.devices_all[remote][channel_device_response['address']].NAME = name
+
                         except Exception as err:
                             LOG.warning(
                                 "RPCFunctions.addDeviceNames: Exception: %s" % str(err))


### PR DESCRIPTION
This pull request:
## Breaking change
- does the following: Adds better namining resolution for channels by modifying the len variable for later resolution in homeassistant/components/homematic/__init__.py:_create_ha_id

- Example: 
  - before: the channel numbers are used as name:
![grafik](https://user-images.githubusercontent.com/4221212/95651690-589a5100-0aec-11eb-9d5f-b4dc6963de37.png)

  - now: Names provide in CCU3 are used:
![grafik](https://user-images.githubusercontent.com/4221212/95651453-cba2c800-0aea-11eb-97e6-8a197939c3d4.png)

- rebased now on devel branch