### PR TITLE
Added support for HmIP-DRSI1

### DIFF
--- a/pyhomematic/devicetypes/actors.py
+++ b/pyhomematic/devicetypes/actors.py
@@ -515,7 +515,7 @@ class IPSwitch(GenericSwitch, HelperActionOnTime):
 
     @property
     def ELEMENT(self):
-        if "HmIP-BSM" in self.TYPE:
+        if "HmIP-BSM" in self.TYPE or "HmIP-DRSI1" in self.TYPE:
             return [4]
         elif "HmIP-PCBS2" in self.TYPE:
             return [4, 8]
@@ -1037,6 +1037,7 @@ DEVICETYPES = {
     "HmIP-PCBS-BAT": IPSwitch,
     "HmIP-PMFS": IPSwitch,
     "HmIP-MOD-OC8": IPSwitch,
+    "HmIP-DRSI1": IPSwitch,    
     "HmIP-DRSI4": IPSwitch,
     "HmIP-BSL": IPKeySwitchLevel,
     "HMIP-PSM": IPSwitchPowermeter,


### PR DESCRIPTION
see details at https://de.elv.com/elv-homematic-ip-komplettbausatz-schaltaktor-fuer-hutschienenmontage-hmip-k-drsi1-154685"

Please point your pull request at the __devel__ branch. Also provide some information about the changes.

This pull request:
- fixes issue: -
- adds support for HomeMatic device: HmIP-DRSI1
  - New class: -
  - Home Assistant [platform](https://github.com/home-assistant/home-assistant/blob/0da3e737651a150c17016f43b5f9144deff7ddd7/homeassistant/components/homematic/__init__.py#L65): \<e.g. `DISCOVER_LIGHTS`>
- does the following: enables usage of the switch
