### PR TITLE
Add Sensornode for HMIP blind actuators with tilt functionality

### DIFF
--- a/pyhomematic/devicetypes/actors.py
+++ b/pyhomematic/devicetypes/actors.py
@@ -105,6 +105,14 @@ class IPKeyBlindMulti(KeyBlind):
 
 
 class IPKeyBlindTilt(IPKeyBlind, HelperActorBlindTilt):
+    """
+    Blind switch that raises, lowers and adjusts the slat position of shutters or blinds.
+    """
+    def __init__(self, device_description, proxy, resolveparamsets=False):
+        super().__init__(device_description, proxy, resolveparamsets)
+
+        # init metadata
+        self.SENSORNODE.update({"LEVEL_2": [3]})
 
     def close_slats(self, channel=None):
         """Move the shutter up all the way."""


### PR DESCRIPTION
This pull request:
- fixes an issue of Homematic IP Blind actuators with tilt functionality (HmIP-BBL, HmIP-FBL) not showing the correct tilt position

Since one of the last updates the HmIP Blind actuators do not report the current positions in channel 4 anymore, but only use channel 4 for writing, and instead channel 3 for showing the current position ("LEVEL") + tilt ("LEVEL_2").

This is NOT an issue whenever a specific tilt position (e.g., 47%) is set (in CCU, Home Assistant, ...) and reached.

It IS an issue whenever the target is not specified (by, e.g., using the manual, regular wall switches, or the arrows in a web UI) and then stopped when the desired position is reached. Channel 4 will then stay in position 0 or 100 and not reflect the actual position. According to EQ-3, this behaviour is intended and will not be changed. Channel 3 should be used for getting the current (tilt) position.

Related discussions: https://github.com/danielperna84/pyhomematic/issues/241#issuecomment-748254645

This is very similar to the commit for the non-tiltable blind actuators: https://github.com/danielperna84/pyhomematic/pull/319/commits/6e8f05fedf27ebea23e2f11ef7d7700e706a45c2