### PR TITLE
Add support for HB-WDS40-THP-O

### DIFF
--- a/pyhomematic/devicetypes/sensors.py
+++ b/pyhomematic/devicetypes/sensors.py
@@ -1173,4 +1173,5 @@ DEVICETYPES = {
     "HmIP-FALMOT-C12": ValveBox,
     "HmIP-SRD": IPRainSensor,
     "HmIP-HAP": IPLanRouter,
+    "HB-WDS40-THP-O": WeatherStation,
 }


### PR DESCRIPTION
This pull request:
- fixes issue: https://github.com/danielperna84/pyhomematic/issues/373
- adds support for HomeMatic device: HB-WDS40-THP-O

My Home Assistant works with this change since one month now without any problems.