### PR TITLE
Fix press_long event for IP Key Dimmer devices

### DIFF
--- a/pyhomematic/devicetypes/actors.py
+++ b/pyhomematic/devicetypes/actors.py
@@ -185,7 +185,7 @@ class IPKeyDimmer(GenericDimmer, HelperActionPress):
 
         # init metadata
         self.EVENTNODE.update({"PRESS_SHORT": [1, 2],
-                               "PRESS_LONG_RELEASE": [1, 2]})
+                               "PRESS_LONG": [1, 2]})
 
     @property
     def ELEMENT(self):


### PR DESCRIPTION
This pull request:
- fixes issue: not working PRESS_LONG event for IP Key dimmer devices like HmIP-BDT
- does the following: Devices like HmIP-BDT are sending the PRESS_LONG event instead of the PRESS_LONG_RELEASE event. With this PR pyhomematic will listen for the PRESS_LONG event for IP Key dimmer devices.
