### PR TITLE
Fix press_short, press_long event for IP Switch devices

### DIFF
--- a/pyhomematic/devicetypes/actors.py
+++ b/pyhomematic/devicetypes/actors.py
@@ -531,7 +531,12 @@ class IPSwitch(GenericSwitch, HelperActionOnTime):
     """
     Switch turning attached device on or off.
     """
+    def __init__(self, device_description, proxy, resolveparamsets=False):
+        super().__init__(device_description, proxy, resolveparamsets)
 
+        self.EVENTNODE.update({"PRESS_SHORT": [1, 2],
+                               "PRESS_LONG": [1, 2]})
+                               
     @property
     def ELEMENT(self):
         if "HmIP-BSM" in self.TYPE:

--- a/pyhomematic/devicetypes/actors.py
+++ b/pyhomematic/devicetypes/actors.py
@@ -536,7 +536,7 @@ class IPSwitch(GenericSwitch, HelperActionOnTime):
 
         self.EVENTNODE.update({"PRESS_SHORT": [1, 2],
                                "PRESS_LONG": [1, 2]})
-                               
+
     @property
     def ELEMENT(self):
         if "HmIP-BSM" in self.TYPE:

--- a/pyhomematic/devicetypes/actors.py
+++ b/pyhomematic/devicetypes/actors.py
@@ -534,8 +534,17 @@ class IPSwitch(GenericSwitch, HelperActionOnTime):
     def __init__(self, device_description, proxy, resolveparamsets=False):
         super().__init__(device_description, proxy, resolveparamsets)
 
-        self.EVENTNODE.update({"PRESS_SHORT": [1, 2],
-                               "PRESS_LONG": [1, 2]})
+        channels = []
+        if "HMIP-PS" in self.TYPE.upper() or "HmIP-PCBS" in self.TYPE or "HmIP-DRSI1" in self.TYPE or "HmIP-FSI16" in self.TYPE:
+            channels = [1]
+        elif "HmIP-MOD-OC8" in self.TYPE:
+            channels = [1,2,3,4,5,6,7,8]
+        elif "HmIP-DRSI4" in self.TYPE:
+            channels = [1,2,3,4]
+
+        if channels:
+            self.EVENTNODE.update({"PRESS_SHORT": channels,
+                                   "PRESS_LONG": channels})
 
     @property
     def ELEMENT(self):


### PR DESCRIPTION
This pull request:
- fixes issue: IP switch devices like the HmIP-DRSI4 are sending the PRESS_LONG and PRESS_SHORT event. But those events are not handled in pyhomematic
- does the following: With this PR, all IP switch devices like the HmIP-DRSI4, are listening for the PRESS_LONG, PRESS_SHORT event.

As the PRESS_LONG, PRESS_SHORT event are now handled in the super class `IPSwitch`, we can maybe also delete the implementation in the following classes:
- `IPKeySwitch`
- `IPSwitchPowermeter`
- `IPKeySwitchPowermeter`

Class `IPKeySwitchPowermeter` can then be deleted completely, because the class would be then empty.

Or as an alternative:
Subclass `IPSwitch` for the HmIP-DRSI4 devices, and insert the logic here.

Let me know how you think about that.

Btw: Du kannst mir auch gerne in Deutsch antworten.