### PR TITLE
HmIP-eTRV-C-2

### DIFF
--- a/pyhomematic/devicetypes/thermostats.py
+++ b/pyhomematic/devicetypes/thermostats.py
@@ -455,6 +455,7 @@ DEVICETYPES = {
     "HmIP-eTRV-B-UK": IPThermostat,
     "HmIP-eTRV-B1": IPThermostat,
     "HmIP-eTRV-C": IPThermostat,
+    "HmIP-eTRV-C-2": IPThermostat,
     "Thermostat AA": IPThermostat,
     "Thermostat AA GB": IPThermostat,
     "HmIP-STHD": IPThermostatWall,


### PR DESCRIPTION
Closes #387

Please point your pull request at the __devel__ branch. Also provide some information about the changes.

This pull request:
- fixes issue: #387
- adds support for HomeMatic device: HmIP-eTRV-C-2
  - New class: -
  - Home Assistant: Just works with this.
- does the following: Registers device as `IPThermostat`. With this, it is recognized and working within Home Assistant without further changes.


