### PR TITLE
Fix HmIP-STHD and HmIP-STH

### DIFF
--- a/pyhomematic/devicetypes/thermostats.py
+++ b/pyhomematic/devicetypes/thermostats.py
@@ -284,42 +284,6 @@ class IPThermostat(HMThermostat, HelperRssiDevice, HelperLowBatIP, HelperValveSt
         self.writeNodeData("SET_POINT_TEMPERATURE", self.OFF_VALUE)
         self.actionNodeData('CONTROL_MODE', self.MANU_MODE)
 
-class IPThermostatWall(HMThermostat, IPAreaThermostat, HelperRssiDevice, HelperLowBatIP):
-    """
-    HmIP-STHD
-    ClimateControl-Wall Thermostat that measures temperature and allows to set a target temperature or use some automatic mode.
-    """
-    def __init__(self, device_description, proxy, resolveparamsets=False):
-        super().__init__(device_description, proxy, resolveparamsets)
-
-        # init metadata
-        self.SENSORNODE.update({"ACTUAL_TEMPERATURE": [1],
-                                "HUMIDITY": [1]})
-        self.WRITENODE.update({"SET_POINT_TEMPERATURE": [1]})
-        self.ACTIONNODE.update({"BOOST_MODE": [1]})
-        self.ATTRIBUTENODE.update({"LOW_BAT": [0],
-                                   "OPERATING_VOLTAGE": [0],
-                                   "SET_POINT_MODE": [1],
-                                   "BOOST_MODE": [1]})
-
-    def get_set_temperature(self):
-        """ Returns the current target temperature. """
-        return self.getWriteData("SET_POINT_TEMPERATURE")
-
-    def set_temperature(self, target_temperature):
-        """ Set the target temperature. """
-        try:
-            target_temperature = float(target_temperature)
-        except Exception as err:
-            LOG.debug("Thermostat.set_temperature: Exception %s" % (err,))
-            return False
-        self.writeNodeData("SET_POINT_TEMPERATURE", target_temperature)
-
-    def turnoff(self):
-        """ Turn off Thermostat. """
-        self.writeNodeData("SET_POINT_TEMPERATURE", self.OFF_VALUE)
-        self.actionNodeData('CONTROL_MODE', self.MANU_MODE)
-
 class IPThermostatWall230V(HMThermostat, IPAreaThermostatNoBattery, HelperRssiDevice):
     """
     HmIP-BWTH, HmIP-BWTH24

--- a/pyhomematic/devicetypes/thermostats.py
+++ b/pyhomematic/devicetypes/thermostats.py
@@ -377,7 +377,7 @@ class IPThermostatWall230V(HMThermostat, IPAreaThermostatNoBattery, HelperRssiDe
 
 class IPThermostatWall2(HMThermostat, IPAreaThermostat, HelperRssiDevice, HelperLowBatIP):
     """
-    HmIP-WTH, HmIP-WTH-2
+    HmIP-WTH, HmIP-WTH-2, HmIP-STHD, HmIP-STH
     ClimateControl-Wall Thermostat that measures temperature and allows to set a target temperature or use some automatic mode.
     """
     def __init__(self, device_description, proxy, resolveparamsets=False):
@@ -458,8 +458,8 @@ DEVICETYPES = {
     "HmIP-eTRV-C-2": IPThermostat,
     "Thermostat AA": IPThermostat,
     "Thermostat AA GB": IPThermostat,
-    "HmIP-STHD": IPThermostatWall,
-    "HmIP-STH": IPThermostatWall,
+    "HmIP-STHD": IPThermostatWall2,
+    "HmIP-STH": IPThermostatWall2,
     "HmIP-WTH-2": IPThermostatWall2,
     "HMIP-WTH-2": IPThermostatWall2,
     "HmIP-WTH-B": IPThermostatWall2,


### PR DESCRIPTION
This PR fixes the issue decribed in #338. The implementation of `HmIP-STHD` and `HmIP-STH` is switched over to the one used by `HmIP-WTH-2`. I do not have `HmIP-STH` devices to test, but I see no reason why those should work differently than the ones with a display.

I gathered information from `HmIP-WTH-2` and `HmIP-STHD` via `get_device_data.py` and compared them with Meld. They only differ in two configuration parameters: the `WTH-2` also exposes a setting to lock the rotary encoder and one to set the display backlight timeout after using the rotary encoder. These are not available on the `STHD` as it is missing the rotary encoder (they use the same PCB, the encoder is just not populated).

I tested this with my `STHD` devices and they now behave like `WTH-2` devices in Home Assistant.

Further, I removed the old implementation as it is not used anymore and somewhat broken anyway.

It would be nice if someone with `STH` devices could confirm that this also works for them.