### PR TITLE
HmIPW-FALMOT-C12

### DIFF
--- a/pyhomematic/devicetypes/sensors.py
+++ b/pyhomematic/devicetypes/sensors.py
@@ -1050,6 +1050,22 @@ class ValveBox(SensorHmIP):
     def ELEMENT(self):
         return [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
 
+class ValveBoxW(SensorHmIPW):
+    """Valve Box HmIPW-FALMOT-C12"""
+
+    def __init__(self, device_description, proxy, resolveparamsets=False):
+        super().__init__(device_description, proxy, resolveparamsets)
+
+        self.SENSORNODE.update({"LEVEL": self.ELEMENT})
+
+    def get_level(self, channel=None):
+        """Return valve state from 0% to 99%"""
+        return float(self.getSensorData("LEVEL", channel))
+
+    @property
+    def ELEMENT(self):
+        return [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+
 class IPLanRouter(HMSensor):
     """ HmIP Lan Router HmIP-HAP"""
 
@@ -1185,6 +1201,7 @@ DEVICETYPES = {
     "HmIP-ASIR": IPAlarmSensor,
     "HmIP-ASIR-2": IPAlarmSensor,
     "HmIP-FALMOT-C12": ValveBox,
+    "HmIPW-FALMOT-C12": ValveBoxW,
     "HmIP-SRD": IPRainSensor,
     "HmIP-HAP": IPLanRouter,
     "HB-WDS40-THP-O": WeatherStation,

--- a/pyhomematic/devicetypes/sensors.py
+++ b/pyhomematic/devicetypes/sensors.py
@@ -1048,7 +1048,7 @@ class ValveBox(SensorHmIP):
 
     @property
     def ELEMENT(self):
-        return [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        return [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
 
 class ValveBoxW(SensorHmIPW):
     """Valve Box HmIPW-FALMOT-C12"""


### PR DESCRIPTION
This pull request:
- adds support for HomeMatic IP device: HmIPW-FALMOT-C12
  - New class: ValveBoxW
  - Home Assistant [platform](https://github.com/home-assistant/home-assistant/blob/0da3e737651a150c17016f43b5f9144deff7ddd7/homeassistant/components/homematic/__init__.py#L65): DISCOVER_SENSORS
- does the following: Adds support for the wired version of the valvebox. It also adds two missing valve channels (11 & 12) in the RF-version (mentioned in #391)
