### PR TITLE
HmIP-MIO16-PCB

### DIFF
--- a/pyhomematic/devicetypes/actors.py
+++ b/pyhomematic/devicetypes/actors.py
@@ -946,7 +946,7 @@ class ColdWarmDimmer(Dimmer):
         return self.setValue(key="LEVEL", channel=self._temp_channel, value=color_temp)
 
 
-class IPMultiIOPCB(HMEvent, GenericSwitch, HelperRssiDevice, HelperRssiPeer):
+class IPMultiIOPCB(GenericSwitch, HelperRssiDevice, HelperRssiPeer):
     """HmIP-MIO16-PCB"""
 
     def __init__(self, device_description, proxy, resolveparamsets=False):
@@ -978,12 +978,10 @@ class IPMultiIOPCB(HMEvent, GenericSwitch, HelperRssiDevice, HelperRssiPeer):
             except Exception as err:
                 LOG.error("IPMultiIOPCB: Failure to determine input channel operations mode of IPMultiIOPCB %s:%i %s", self._ADDRESS, chan, err)
 
-        self.ACTIONNODE.update({"PRESS_SHORT": self._keypress_event_channels,
-                                "PRESS_LONG": self._keypress_event_channels})
         self.BINARYNODE.update({"STATE": self._binarysensor_channels})
-
         self.SENSORNODE.update({"VOLTAGE": self._aic})
-
+        # button events not successfully implemented yet (SHORT_PRESS, LOMG_PRESS)
+        
     def get_voltage(self, channel=None):
         """Return analog input in V"""
         return float(self.getSensorData("VOLTAGE", channel))


### PR DESCRIPTION
This pull request:
- adds support for HomeMatic device: HmIP-MIO16-PCB
  - New class: IPMultiIOPCB
  - Home Assistant [platform](https://github.com/home-assistant/home-assistant/blob/0da3e737651a150c17016f43b5f9144deff7ddd7/homeassistant/components/homematic/__init__.py#L65): `DISCOVER_SWITCHES, DISCOVER_SENSORS, DISCOVER_BINARY_SENSORS`
- does the following: This PR adds support for HmIP-MIO16-PCB. Please have a look if everything seems to be ok as I am not experienced in python and copied everything together. 
- Notes: One thing that I couldn't figure out during my tests is (how) to receive press events of an input configured as button ("Taster"). Configured as contact the input updates its value immediately. As normal switch it doesn't (I guess the CCU gets the update with the next periodic update of the device OR when a contact input changes).
- [Device and paramset description](https://gist.github.com/Knechtie/2fb503cd07dc49195aecaa92d5a85b36)
