### PR TITLE
HM-ES-TX-WM with ES-IEC adapter

### DIFF
--- a/pyhomematic/devicetypes/sensors.py
+++ b/pyhomematic/devicetypes/sensors.py
@@ -220,7 +220,9 @@ class PowermeterGas(SensorHm):
         self.SENSORNODE.update({"GAS_ENERGY_COUNTER": [1],
                                 "GAS_POWER": [1],
                                 "ENERGY_COUNTER": [1],
-                                "POWER": [1]})
+                                "POWER": [1],
+                                "IEC_ENERGY_COUNTER": [1,2],
+                                "IEC_POWER": [1,2]})
 
     def get_gas_counter(self, channel=None):
         """Return gas counter."""
@@ -237,6 +239,14 @@ class PowermeterGas(SensorHm):
     def get_power(self, channel=None):
         """Return power counter."""
         return float(self.getSensorData("POWER", channel))
+      
+    def get_iec_energy(self, channel=None):
+        """Return iec energy counter."""
+        return float(self.getSensorData("IEC_ENERGY_COUNTER", channel))
+
+    def get_iec_power(self, channel=None):
+        """Return iec power counter."""
+        return float(self.getSensorData("IEC_POWER", channel))
 
 
 class Smoke(SensorHm, HelperBinaryState):


### PR DESCRIPTION
Add two fields of "IEC_ENERGY_COUNTER" and two fields of "IEC_POWER" to PowermeterGas class.
Needed for firmware 2.5 in combination with ES-IEC adapter.
An additional pull requests for HomeAssistant (for unit definition) I will link later.

This pull request:
- fixes issue: https://github.com/danielperna84/pyhomematic/issues/374
- adds support for HomeMatic device: HM-ES-TX-WM with ES-IEC adapter
  - New class: Extend `PowermeterGas`
  - Home Assistant [platform] Link will come later
- does the following: See above
