### PR TITLE
WIP: Add profiles (aka. Wochenprogramm) to HMIP thermostats + additional fixes

### DIFF
--- a/pyhomematic/devicetypes/actors.py
+++ b/pyhomematic/devicetypes/actors.py
@@ -1009,7 +1009,7 @@ class IPMultiIOPCB(GenericSwitch, HelperRssiDevice, HelperRssiPeer):
         self.BINARYNODE.update({"STATE": self._binarysensor_channels})
         self.SENSORNODE.update({"VOLTAGE": self._aic})
         # button events not successfully implemented yet (SHORT_PRESS, LOMG_PRESS)
-        
+
     def get_voltage(self, channel=None):
         """Return analog input in V"""
         return float(self.getSensorData("VOLTAGE", channel))

--- a/pyhomematic/devicetypes/generic.py
+++ b/pyhomematic/devicetypes/generic.py
@@ -357,11 +357,14 @@ class HMDevice(HMGeneric):
                 nodeChannel = channel if channel is not None else nodeChannelList[0]
             elif len(nodeChannelList) == 1:
                 nodeChannel = nodeChannelList[0]
-            if nodeChannel is not None and nodeChannel in self.CHANNELS:
+            if nodeChannel in self.CHANNELS:
                 return self._hmchannels[nodeChannel].setValue(name, data)
-
-        LOG.error("HMDevice.setNodeData: %s not found with value %s on %i" %
-                  (name, data, nodeChannel))
+            else:
+                LOG.error("HMDevice.setNodeData: invalid channel %i for %s" %
+                          (nodeChannel, name))
+        else:
+            LOG.error("HMDevice.setNodeData: channel for %s not found" %
+                      (name,))
         return False
 
     def get_rssi(self, channel=0):

--- a/pyhomematic/devicetypes/sensors.py
+++ b/pyhomematic/devicetypes/sensors.py
@@ -239,7 +239,7 @@ class PowermeterGas(SensorHm):
     def get_power(self, channel=None):
         """Return power counter."""
         return float(self.getSensorData("POWER", channel))
-      
+
     def get_iec_energy(self, channel=None):
         """Return iec energy counter."""
         return float(self.getSensorData("IEC_ENERGY_COUNTER", channel))

--- a/pyhomematic/devicetypes/thermostats.py
+++ b/pyhomematic/devicetypes/thermostats.py
@@ -23,8 +23,6 @@ class HMThermostat(HMDevice):
         self.LOWERING_MODE = 5
         self.OFF_VALUE = 4.5
 
-        self.mode = None
-
     def actual_temperature(self):
         """ Returns the current temperature. """
         return self.getSensorData("ACTUAL_TEMPERATURE")
@@ -75,32 +73,32 @@ class HMThermostat(HMDevice):
     @property
     def AUTOMODE(self):
         """ Return auto mode state. """
-        return self.mode == self.AUTO_MODE
+        return self.MODE == self.AUTO_MODE
 
     @property
     def MANUMODE(self):
         """ Return manual mode state. """
-        return self.mode == self.MANU_MODE
+        return self.MODE == self.MANU_MODE
 
     @property
     def PARTYMODE(self):
         """ Return party mode state. """
-        return self.mode == self.PARTY_MODE
+        return self.MODE == self.PARTY_MODE
 
     @property
     def BOOSTMODE(self):
         """ Return boost state. """
-        return self.mode == self.BOOST_MODE
+        return self.MODE == self.BOOST_MODE
 
     @property
     def COMFORTMODE(self):
         """ Return comfort state. """
-        return self.mode == self.COMFORT_MODE
+        return self.MODE == self.COMFORT_MODE
 
     @property
     def LOWERINGMODE(self):
         """ Return lowering state. """
-        return self.mode == self.LOWERING_MODE
+        return self.MODE == self.LOWERING_MODE
 
 
 class ThermostatGroup(HMThermostat):


### PR DESCRIPTION
I'd like to add profiles (aka. Wochenprogramm) to home assistant presets (similar to the homematic_ip component). [home assistant part here](https://github.com/neffs/home-assistant/tree/homematic-profiles).

I think the right way is to add ACTIVE_PROFILES to pyhomematic first. I added it to ATTRIBUTENODES, which ich the primary change of this PR. I'm not sure if this is the correct choice, I'll be happy to take different suggestions.

I also refactored the HMIP thermostat code with a common base class. This makes the commit a little larger.

I also fixed some unrelated minor issues in separate commits.