### PR TITLE
Add HmIP-DRDI3

### DIFF
--- a/pyhomematic/devicetypes/actors.py
+++ b/pyhomematic/devicetypes/actors.py
@@ -167,13 +167,28 @@ class KeyDimmer(GenericDimmer, HelperInhibit, HelperWorking, HelperActionPress):
 
 class IPDimmer(GenericDimmer):
     """
-    IP Dimmer switch that controls level of light brightness.
+    IP Dimmer switch and DRDI3 that controls level of light brightness.
     """
+    def __init__(self, device_description, proxy, resolveparamsets=False):
+        super().__init__(device_description, proxy, resolveparamsets)
+
+        channels = []
+        if "HmIP-DRDI3" in self.TYPE:
+            channels = [1,2,3]
+
+        if channels:
+            self.EVENTNODE.update({"PRESS_SHORT": channels,
+                                   "PRESS_LONG": channels})
+
     @property
     def ELEMENT(self):
         if "PDT" in self._TYPE:
             return [3]
-        return [2]
+        elif "HmIP-DRDI3" in self._TYPE:
+            return [5,9,13]
+        else:
+            return [2]
+
 
 
 class IPKeyDimmer(GenericDimmer, HelperActionPress):
@@ -1169,6 +1184,7 @@ DEVICETYPES = {
     "HmIP-BDT": IPKeyDimmer,
     "HmIP-FDT": IPDimmer,
     "HmIP-PDT": IPDimmer,
+    "HmIP-DRDI3": IPDimmer,
     "HmIP-PDT-UK": IPDimmer,
     "HM-Sec-Key": KeyMatic,
     "HM-Sec-Key-S": KeyMatic,


### PR DESCRIPTION
Hi.

I have added DRDI3 devices to actors.py. It works in my environment but I would love to see it in one of the next releases of Home Assistant, that I have a working environment, which I don't have to manually modify ;) Here some details:

This pull request:
- fixes issue: NO OPEN ISSUE / But it was discussed in https://github.com/danielperna84/pyhomematic/issues/28 as nice to have
- adds support for HomeMatic device: HmIP-DRDI3
- does the following: 
    - Lights can be discovered, switched and dimmed by Home Assistant
    - Switches may be usable within Home Assistant. I don't have them tested since I don't have switches attached, I have followed the logic of other devices in actors.py
 
Example Output in CCU3 xmlapi:
```
<device name="HmIP-DRDI3 XXXXXXXXXXXXXX" address="XXXXXXXXXXXXXX" ise_id="10695" interface="HmIP-RF" device_type="HmIP-DRDI3" ready_config="true">
<channel name="HmIP-DRDI3 XXXXXXXXXXXXXX:0" type="30" address="XXXXXXXXXXXXXX:0" ise_id="10696" direction="UNKNOWN" parent_device="10695" index="0" group_partner="" aes_available="false" transmission_mode="AES" visible="true" ready_config="true" operate="true"/>
<channel name="HmIP-DRDI3 XXXXXXXXXXXXXX:1" type="28" address="XXXXXXXXXXXXXX:1" ise_id="10729" direction="SENDER" parent_device="10695" index="1" group_partner="" aes_available="false" transmission_mode="AES" visible="true" ready_config="true" operate="true"/>
<channel name="HmIP-DRDI3 XXXXXXXXXXXXXX:2" type="28" address="XXXXXXXXXXXXXX:2" ise_id="10733" direction="SENDER" parent_device="10695" index="2" group_partner="" aes_available="false" transmission_mode="AES" visible="true" ready_config="true" operate="true"/>
<channel name="HmIP-DRDI3 XXXXXXXXXXXXXX:3" type="28" address="XXXXXXXXXXXXXX:3" ise_id="10737" direction="SENDER" parent_device="10695" index="3" group_partner="" aes_available="false" transmission_mode="AES" visible="true" ready_config="true" operate="true"/>
<channel name="HmIP-DRDI3 XXXXXXXXXXXXXX:4" type="27" address="XXXXXXXXXXXXXX:4" ise_id="10741" direction="UNKNOWN" parent_device="10695" index="4" group_partner="" aes_available="false" transmission_mode="AES" visible="true" ready_config="true" operate="true"/>
<channel name="HmIP-DRDI3 XXXXXXXXXXXXXX:5" type="27" address="XXXXXXXXXXXXXX:5" ise_id="10762" direction="RECEIVER" parent_device="10695" index="5" group_partner="" aes_available="false" transmission_mode="AES" visible="true" ready_config="true" operate="true"/>
<channel name="HmIP-DRDI3 XXXXXXXXXXXXXX:6" type="27" address="XXXXXXXXXXXXXX:6" ise_id="10772" direction="RECEIVER" parent_device="10695" index="6" group_partner="" aes_available="false" transmission_mode="AES" visible="true" ready_config="true" operate="true"/>
<channel name="HmIP-DRDI3 XXXXXXXXXXXXXX:7" type="27" address="XXXXXXXXXXXXXX:7" ise_id="10782" direction="RECEIVER" parent_device="10695" index="7" group_partner="" aes_available="false" transmission_mode="AES" visible="true" ready_config="true" operate="true"/>
<channel name="HmIP-DRDI3 XXXXXXXXXXXXXX:8" type="27" address="XXXXXXXXXXXXXX:8" ise_id="10792" direction="UNKNOWN" parent_device="10695" index="8" group_partner="" aes_available="false" transmission_mode="AES" visible="true" ready_config="true" operate="true"/>
<channel name="HmIP-DRDI3 XXXXXXXXXXXXXX:9" type="27" address="XXXXXXXXXXXXXX:9" ise_id="10813" direction="RECEIVER" parent_device="10695" index="9" group_partner="" aes_available="false" transmission_mode="AES" visible="true" ready_config="true" operate="true"/>
<channel name="HmIP-DRDI3 XXXXXXXXXXXXXX:10" type="27" address="XXXXXXXXXXXXXX:10" ise_id="10823" direction="RECEIVER" parent_device="10695" index="10" group_partner="" aes_available="false" transmission_mode="AES" visible="true" ready_config="true" operate="true"/>
<channel name="HmIP-DRDI3 XXXXXXXXXXXXXX:11" type="27" address="XXXXXXXXXXXXXX:11" ise_id="10833" direction="RECEIVER" parent_device="10695" index="11" group_partner="" aes_available="false" transmission_mode="AES" visible="true" ready_config="true" operate="true"/>
<channel name="HmIP-DRDI3 XXXXXXXXXXXXXX:12" type="27" address="XXXXXXXXXXXXXX:12" ise_id="10843" direction="UNKNOWN" parent_device="10695" index="12" group_partner="" aes_available="false" transmission_mode="AES" visible="true" ready_config="true" operate="true"/>
<channel name="HmIP-DRDI3 XXXXXXXXXXXXXX:13" type="27" address="XXXXXXXXXXXXXX:13" ise_id="10864" direction="RECEIVER" parent_device="10695" index="13" group_partner="" aes_available="false" transmission_mode="AES" visible="true" ready_config="true" operate="true"/>
<channel name="HmIP-DRDI3 XXXXXXXXXXXXXX:14" type="27" address="XXXXXXXXXXXXXX:14" ise_id="10874" direction="RECEIVER" parent_device="10695" index="14" group_partner="" aes_available="false" transmission_mode="AES" visible="true" ready_config="true" operate="true"/>
<channel name="HmIP-DRDI3 XXXXXXXXXXXXXX:15" type="27" address="XXXXXXXXXXXXXX:15" ise_id="10884" direction="RECEIVER" parent_device="10695" index="15" group_partner="" aes_available="false" transmission_mode="AES" visible="true" ready_config="true" operate="true"/>
<channel name="HmIP-DRDI3 XXXXXXXXXXXXXX:16" type="27" address="XXXXXXXXXXXXXX:16" ise_id="10894" direction="UNKNOWN" parent_device="10695" index="16" group_partner="" aes_available="false" transmission_mode="AES" visible="true" ready_config="true" operate="true"/>
</device>
```