### PR TITLE
Add HmIP-DRDI3 to IPKeyDimmer Class

### DIFF
--- a/pyhomematic/devicetypes/actors.py
+++ b/pyhomematic/devicetypes/actors.py
@@ -185,9 +185,9 @@ class IPKeyDimmer(GenericDimmer, HelperActionPress):
 
         channels = []
         if "HMIP-DRDI3" in self.TYPE.upper():
-            channels = [1,2,3]
-        elif "HMIP-BDT" in self.TYPE.upper():
-            channels = [1,2]
+            channels = [1, 2, 3]
+        else:
+            channels = [1, 2]
 
         # init metadata
         self.EVENTNODE.update({"PRESS_SHORT": channels,
@@ -196,8 +196,8 @@ class IPKeyDimmer(GenericDimmer, HelperActionPress):
     @property
     def ELEMENT(self):
         if "HMIP-DRDI3" in self.TYPE.upper():
-            return [5,9,13]
-        elif "HMIP-BDT" in self.TYPE.upper():
+            return [5, 9, 13]
+        else:
             return [4]
 
 

--- a/pyhomematic/devicetypes/actors.py
+++ b/pyhomematic/devicetypes/actors.py
@@ -197,7 +197,7 @@ class IPKeyDimmer(GenericDimmer, HelperActionPress):
     def ELEMENT(self):
         if "HMIP-DRDI3" in self.TYPE.upper():
             return [5,9,13]
-        elif "HMIP-BDT" in self.TYPE.upper()
+        elif "HMIP-BDT" in self.TYPE.upper():
             return [4]
 
 

--- a/pyhomematic/devicetypes/actors.py
+++ b/pyhomematic/devicetypes/actors.py
@@ -183,13 +183,22 @@ class IPKeyDimmer(GenericDimmer, HelperActionPress):
     def __init__(self, device_description, proxy, resolveparamsets=False):
         super().__init__(device_description, proxy, resolveparamsets)
 
+        channels = []
+        if "HMIP-DRDI3" in self.TYPE.upper():
+            channels = [1,2,3]
+        elif "HMIP-BDT" in self.TYPE.upper():
+            channels = [1,2]
+
         # init metadata
-        self.EVENTNODE.update({"PRESS_SHORT": [1, 2],
-                               "PRESS_LONG": [1, 2]})
+        self.EVENTNODE.update({"PRESS_SHORT": channels,
+                               "PRESS_LONG": channels})
 
     @property
     def ELEMENT(self):
-        return [4]
+        if "HMIP-DRDI3" in self.TYPE.upper():
+            return [5,9,13]
+        elif "HMIP-BDT" in self.TYPE.upper()
+            return [4]
 
 
 class GenericSwitch(HMActor, HelperActorState):
@@ -1167,6 +1176,7 @@ DEVICETYPES = {
     "HmIP-BSM": IPKeySwitchPowermeter,
     "HMIP-BDT": IPKeyDimmer,
     "HmIP-BDT": IPKeyDimmer,
+    "HmIP-DRDI3": IPKeyDimmer,
     "HmIP-FDT": IPDimmer,
     "HmIP-PDT": IPDimmer,
     "HmIP-PDT-UK": IPDimmer,


### PR DESCRIPTION
This commit...
fixes issue: NO OPEN ISSUE / But it was discussed in #28 as nice to have (and I do have 4 of them, currently...)
adds support for HomeMatic device: HmIP-DRDI3
does the following:
Lights can be discovered, switched and dimmed by Home Assistant
Switches are usable within Home Assistant.

The Outputs of get_device_data.py are located there:
https://gist.github.com/gbotti/7d13778935390ab789264073be92f0f6#file-hmip-drdi3-json
https://gist.github.com/gbotti/7364664a41060e6a779d4fb48309e738#file-hmip-drdi3-json

I have also checked DOOR_SENSOR.STATE, please see pull request #408 discussion. In first place I have just added the device that it can be used. If we can clarify if this would be interesting to implement, I will do that ;)

Example Output in CCU3 xmlapi:
```
<device name="HmIP-DRDI3 XXXXXXXXXXXXXX" address="XXXXXXXXXXXXXX" ise_id="10695" interface="HmIP-RF" device_type="HmIP-DRDI3" ready_config="true">
<channel name="HmIP-DRDI3 XXXXXXXXXXXXXX:0" type="30" address="XXXXXXXXXXXXXX:0" ise_id="10696" direction="UNKNOWN" parent_device="10695" index="0" group_partner="" aes_available="false" transmission_mode="AES" visible="true" ready_config="true" operate="true"/>
<channel name="HmIP-DRDI3 XXXXXXXXXXXXXX:1" type="28" address="XXXXXXXXXXXXXX:1" ise_id="10729" direction="SENDER" parent_device="10695" index="1" group_partner="" aes_available="false" transmission_mode="AES" visible="true" ready_config="true" operate="true"/>
<channel name="HmIP-DRDI3 XXXXXXXXXXXXXX:2" type="28" address="XXXXXXXXXXXXXX:2" ise_id="10733" direction="SENDER" parent_device="10695" index="2" group_partner="" aes_available="false" transmission_mode="AES" visible="true" ready_config="true" operate="true"/>
<channel name="HmIP-DRDI3 XXXXXXXXXXXXXX:3" type="28" address="XXXXXXXXXXXXXX:3" ise_id="10737" direction="SENDER" parent_device="10695" index="3" group_partner="" aes_available="false" transmission_mode="AES" visible="true" ready_config="true" operate="true"/>
<channel name="HmIP-DRDI3 XXXXXXXXXXXXXX:4" type="27" address="XXXXXXXXXXXXXX:4" ise_id="10741" direction="UNKNOWN" parent_device="10695" index="4" group_partner="" aes_available="false" transmission_mode="AES" visible="true" ready_config="true" operate="true"/>
<channel name="HmIP-DRDI3 XXXXXXXXXXXXXX:5" type="27" address="XXXXXXXXXXXXXX:5" ise_id="10762" direction="RECEIVER" parent_device="10695" index="5" group_partner="" aes_available="false" transmission_mode="AES" visible="true" ready_config="true" operate="true"/>
<channel name="HmIP-DRDI3 XXXXXXXXXXXXXX:6" type="27" address="XXXXXXXXXXXXXX:6" ise_id="10772" direction="RECEIVER" parent_device="10695" index="6" group_partner="" aes_available="false" transmission_mode="AES" visible="true" ready_config="true" operate="true"/>
<channel name="HmIP-DRDI3 XXXXXXXXXXXXXX:7" type="27" address="XXXXXXXXXXXXXX:7" ise_id="10782" direction="RECEIVER" parent_device="10695" index="7" group_partner="" aes_available="false" transmission_mode="AES" visible="true" ready_config="true" operate="true"/>
<channel name="HmIP-DRDI3 XXXXXXXXXXXXXX:8" type="27" address="XXXXXXXXXXXXXX:8" ise_id="10792" direction="UNKNOWN" parent_device="10695" index="8" group_partner="" aes_available="false" transmission_mode="AES" visible="true" ready_config="true" operate="true"/>
<channel name="HmIP-DRDI3 XXXXXXXXXXXXXX:9" type="27" address="XXXXXXXXXXXXXX:9" ise_id="10813" direction="RECEIVER" parent_device="10695" index="9" group_partner="" aes_available="false" transmission_mode="AES" visible="true" ready_config="true" operate="true"/>
<channel name="HmIP-DRDI3 XXXXXXXXXXXXXX:10" type="27" address="XXXXXXXXXXXXXX:10" ise_id="10823" direction="RECEIVER" parent_device="10695" index="10" group_partner="" aes_available="false" transmission_mode="AES" visible="true" ready_config="true" operate="true"/>
<channel name="HmIP-DRDI3 XXXXXXXXXXXXXX:11" type="27" address="XXXXXXXXXXXXXX:11" ise_id="10833" direction="RECEIVER" parent_device="10695" index="11" group_partner="" aes_available="false" transmission_mode="AES" visible="true" ready_config="true" operate="true"/>
<channel name="HmIP-DRDI3 XXXXXXXXXXXXXX:12" type="27" address="XXXXXXXXXXXXXX:12" ise_id="10843" direction="UNKNOWN" parent_device="10695" index="12" group_partner="" aes_available="false" transmission_mode="AES" visible="true" ready_config="true" operate="true"/>
<channel name="HmIP-DRDI3 XXXXXXXXXXXXXX:13" type="27" address="XXXXXXXXXXXXXX:13" ise_id="10864" direction="RECEIVER" parent_device="10695" index="13" group_partner="" aes_available="false" transmission_mode="AES" visible="true" ready_config="true" operate="true"/>
<channel name="HmIP-DRDI3 XXXXXXXXXXXXXX:14" type="27" address="XXXXXXXXXXXXXX:14" ise_id="10874" direction="RECEIVER" parent_device="10695" index="14" group_partner="" aes_available="false" transmission_mode="AES" visible="true" ready_config="true" operate="true"/>
<channel name="HmIP-DRDI3 XXXXXXXXXXXXXX:15" type="27" address="XXXXXXXXXXXXXX:15" ise_id="10884" direction="RECEIVER" parent_device="10695" index="15" group_partner="" aes_available="false" transmission_mode="AES" visible="true" ready_config="true" operate="true"/>
<channel name="HmIP-DRDI3 XXXXXXXXXXXXXX:16" type="27" address="XXXXXXXXXXXXXX:16" ise_id="10894" direction="UNKNOWN" parent_device="10695" index="16" group_partner="" aes_available="false" transmission_mode="AES" visible="true" ready_config="true" operate="true"/>
</device>
```

Please point your pull request at the __devel__ branch. Also provide some information about the changes.

This pull request:
- fixes issue: \<Link to issue>
- adds support for HomeMatic device: \<Device name goes here, e.g. HmIP-ABC-DEF>
  - New class: \<e.g. YourSensor>
  - Home Assistant [platform](https://github.com/home-assistant/home-assistant/blob/0da3e737651a150c17016f43b5f9144deff7ddd7/homeassistant/components/homematic/__init__.py#L65): \<e.g. `DISCOVER_LIGHTS`>
- does the following: \<Description of what the change is intended to do>
