### PR TITLE
HmIP-BWTH add switching state for heating valve

### DIFF
--- a/pyhomematic/devicetypes/thermostats.py
+++ b/pyhomematic/devicetypes/thermostats.py
@@ -299,7 +299,8 @@ class IPThermostatWall230V(HMThermostat, IPAreaThermostatNoBattery, HelperRssiDe
                                 "CONTROL_MODE": [1],
                                 "BOOST_MODE": [1]})
         self.ATTRIBUTENODE.update({"SET_POINT_MODE": [1],
-                                   "BOOST_MODE": [1]})
+                                   "BOOST_MODE": [1],
+                                   "STATE": [8]})
 
     def get_set_temperature(self):
         """ Returns the current target temperature. """


### PR DESCRIPTION
Added the switching state for the heating valve on channel 8.
for devices: HmIP-BWTH and HmIP-BWTH24

I'm not sure if it would be better to implement a class HelperValveBinaryState?
But currently i don't know how to rename/map the "STATE" channel.

![image](https://user-images.githubusercontent.com/3747263/124586837-3c4afb00-de57-11eb-86fb-eaff07505cb6.png)

