### PR TITLE
Add support for HmIP-SCTH230

### DIFF
--- a/pyhomematic/devicetypes/sensors.py
+++ b/pyhomematic/devicetypes/sensors.py
@@ -195,6 +195,20 @@ class CO2Sensor(SensorHm, HelperSensorState):
         return self.get_state(channel) == 2
 
 
+class CO2SensorIP(SensorHmIPNoBattery):
+    """CO2 Sensor
+        partial support for HmIP-SCTH230
+        missing relay state and actions
+    """
+
+    def __init__(self, device_description, proxy, resolveparamsets=False):
+        super().__init__(device_description, proxy, resolveparamsets)
+        self.SENSORNODE.update({"CONCENTRATION": [1],
+                                "CONCENTRATION_STATUS": [1],
+                                "HUMIDITY": [4],
+                                "ACTUAL_TEMPERATURE": [4]
+                                })
+
 class WaterSensor(SensorHm, HelperSensorState):
     """Watter detect sensor."""
 
@@ -1215,5 +1229,6 @@ DEVICETYPES = {
     "HmIP-SRD": IPRainSensor,
     "HmIP-HAP": IPLanRouter,
     "HB-WDS40-THP-O": WeatherStation,
-    "HmIP-STE2-PCB": TempModuleSTE2
+    "HmIP-STE2-PCB": TempModuleSTE2,
+    "HmIP-SCTH230": CO2SensorIP
 }


### PR DESCRIPTION
Please point your pull request at the __devel__ branch. Also provide some information about the changes.

This pull request:
- fixes issue: #419
- adds support for HomeMatic device: HmIP-SCTH230
  - New class: CO2SensorIP
  - Home Assistant [platform](https://github.com/home-assistant/home-assistant/blob/0da3e737651a150c17016f43b5f9144deff7ddd7/homeassistant/components/homematic/__init__.py#L65): `DISCOVER_SENSORS
   - Home Assistant sensors.py: HM_DEVICE_CLASS_HA_CAST append `"CONCENTRATION": DEVICE_CLASS_CO2`
   - Home Assistant sensors.py: HM_UNIT_HA_CAST append `"CONCENTRATION": CONCENTRATION_PARTS_PER_MILLION,`
   - Home Assistant consts exist and must be imported.
- does the following: Shows Concentration of CO2 in ppm, CO2-Status (numeric, values in CCU unknown yet), Humidity, Temperature.
- misses: relay state and action, led control
