### PR TITLE
Add support for HmIP-WGC

### DIFF
--- a/pyhomematic/devicetypes/actors.py
+++ b/pyhomematic/devicetypes/actors.py
@@ -839,12 +839,18 @@ class IPGarage(GenericSwitch, GenericBlind, HMSensor):
         return [2]
 
 
-class IPGarageSwitch(GenericSwitch, HMSensor):
+class IPGarageSwitch(GenericSwitch, HelperEventRemote, HMSensor):
     """
-    HmIP-WGC
+    HmIP-WGC Garage Actor
     """
     def __init__(self, device_description, proxy, resolveparamsets=False):
         super().__init__(device_description, proxy, resolveparamsets)
+
+        # init metadata
+        self.SENSORNODE.update({"LOW_BAT": [0],
+                                "OPERATING_VOLTAGE": [0],
+                                "RSSI_DEVICE": [0],
+                                "RSSI_PEER": [0]})
 
     @property
     def ELEMENT(self):

--- a/pyhomematic/devicetypes/actors.py
+++ b/pyhomematic/devicetypes/actors.py
@@ -847,10 +847,10 @@ class IPGarageSwitch(GenericSwitch, HelperEventRemote, HMSensor):
         super().__init__(device_description, proxy, resolveparamsets)
 
         # init metadata
-        self.SENSORNODE.update({"LOW_BAT": [0],
-                                "OPERATING_VOLTAGE": [0],
-                                "RSSI_DEVICE": [0],
-                                "RSSI_PEER": [0]})
+        self.ATTRIBUTENODE.update({"LOW_BAT": [0],
+                                   "OPERATING_VOLTAGE": [0],
+                                   "RSSI_DEVICE": [0],
+                                   "RSSI_PEER": [0]})
 
     @property
     def ELEMENT(self):

--- a/pyhomematic/devicetypes/actors.py
+++ b/pyhomematic/devicetypes/actors.py
@@ -839,6 +839,18 @@ class IPGarage(GenericSwitch, GenericBlind, HMSensor):
         return [2]
 
 
+class IPGarageSwitch(GenericSwitch, HMSensor):
+    """
+    HmIP-WGC
+    """
+    def __init__(self, device_description, proxy, resolveparamsets=False):
+        super().__init__(device_description, proxy, resolveparamsets)
+
+    @property
+    def ELEMENT(self):
+        return [3]
+
+
 class IPMultiIO(IPSwitch):
     """
     HmIP-MIOB Multi IO Box
@@ -1190,6 +1202,7 @@ DEVICETYPES = {
     "HM-Sec-Sir-WM": RFSiren,
     "HmIP-MOD-HO": IPGarage,
     "HmIP-MOD-TM": IPGarage,
+    "HmIP-WGC": IPGarageSwitch,
     "HM-LC-RGBW-WM": ColorEffectLight,
     "HmIP-MIOB": IPMultiIO,
     "HM-DW-WM": Dimmer,


### PR DESCRIPTION
Please point your pull request at the __devel__ branch. Also provide some information about the changes.

This pull request:
- fixes issue: #342 
- adds support for HomeMatic device: HmIP-WGC
  - New class: IPGarageSwitch
  - Home Assistant [platform](https://github.com/home-assistant/home-assistant/blob/0da3e737651a150c17016f43b5f9144deff7ddd7/homeassistant/components/homematic/__init__.py#L65): \<e.g. `DISCOVER_LIGHTS`>
  - Home Assistant const.py: DISCOVER_SWITCHES append "IPGarageSwitch"
- does the following: Triggers Open / Stop / Close of a garage door
