### PR TITLE
Add sabotage attribute to HmIP-SMI

### DIFF
--- a/pyhomematic/devicetypes/sensors.py
+++ b/pyhomematic/devicetypes/sensors.py
@@ -450,6 +450,34 @@ class MotionIP(SensorHmIP):
         return [0, 1]
 
 
+class MotionIPContactSabotage(SensorHmIP, HelperSabotageIP):
+    """Motion detection indoor (rf ip)
+       This is a binary sensor."""
+
+    def __init__(self, device_description, proxy, resolveparamsets=False):
+        super().__init__(device_description, proxy, resolveparamsets)
+
+        # init metadata
+        self.BINARYNODE.update({"MOTION_DETECTION_ACTIVE": [1], "MOTION": [1]})
+        self.SENSORNODE.update({"ILLUMINATION": [1]})
+        self.ATTRIBUTENODE.update({"ERROR_CODE": [0]})
+
+    def is_motion(self, channel=None):
+        """ Return True if motion is detected """
+        return bool(self.getBinaryData("MOTION", channel))
+
+    def is_motion_detection_active(self, channel=None):
+        return bool(self.getBinaryData("MOTION_DETECTION_ACTIVE", channel))
+
+    def get_brightness(self, channel=None):
+        """ Return brightness from 0 (dark) to 163830 (bright) """
+        return float(self.getSensorData("ILLUMINATION", channel))
+
+    @property
+    def ELEMENT(self):
+        return [0, 1]      
+
+      
 class MotionIPV2(SensorHmIP):
     """Motion detection indoor 55 (rf ip)
        This is a binary sensor."""
@@ -1160,7 +1188,7 @@ DEVICETYPES = {
     "HM-Sec-MDIR": MotionV2,
     "263 162": MotionV2,
     "HM-Sec-MD": MotionV2,
-    "HmIP-SMI": MotionIP,
+    "HmIP-SMI": MotionIPContactSabotage,
     "HmIP-SMI55": IPRemoteMotionV2,
     "HmIP-SMO": MotionIP,
     "HmIP-SMO-A": MotionIP,


### PR DESCRIPTION
Added a new class for MotionIP with Sabotage to secure, that there is thill MotionIP without, if there are or will be other devices out there and assigned this new class to HmIP-SMI.

Please point your pull request at the __devel__ branch. Also provide some information about the changes.

This pull request:
- fixes issue: no Sabotage Attribute in 
- adds support for HomeMatic device: `HmIP-SMI`
  - New class:  `MotionIPContactSabotage`
  - Home Assistant [platform](https://github.com/home-assistant/home-assistant/blob/0da3e737651a150c17016f43b5f9144deff7ddd7/homeassistant/components/homematic/__init__.py#L65): `DISCOVER_BINARY_SENSORS`
- does the following: Add sabotage attribute to HmIP-SMI
