### PR TITLE
enable support for HM-Sec-SD-2-Team

### DIFF
--- a/pyhomematic/devicetypes/json/device_details.json
+++ b/pyhomematic/devicetypes/json/device_details.json
@@ -59,7 +59,7 @@
     "HM-LC-Sw2PBU-FM": {},
     "HM-LC-Dim1T-DR": {},
     "HM-RC-4-3": {},
-    "HM-Sec-SD-2-Team": {"supported": false},
+    "HM-Sec-SD-2-Team": {},
     "HmIP-FSM16": {"supported": false},
     "HM-LC-RGBW-WM": {},
     "HMIP-WTH": {},

--- a/pyhomematic/devicetypes/sensors.py
+++ b/pyhomematic/devicetypes/sensors.py
@@ -286,6 +286,21 @@ class SmokeV2(SensorHm, HelperBinaryState):
         """ Return True if smoke is detected """
         return self.get_state(channel)
 
+class SmokeV2Team(HMSensor, HelperBinaryState):
+    """This is a group of smoke sensors. In such a configuration only the
+       virtual team device will emit a smoke detected event."""
+
+    def __init__(self, device_description, proxy, resolveparamsets=False):
+        super().__init__(device_description, proxy, resolveparamsets)
+
+        self.BINARYNODE.update({"STATE": [1]})
+
+        self.ATTRIBUTENODE.update({"SENDERADDRESS": [1],
+                                   "SENDERID": [1]})
+
+    def is_smoke(self, channel=None):
+        """ Return True if smoke is detected """
+        return self.get_state(channel)
 
 class IPSmoke(SensorHmIPNoVoltage):
     """HomeMatic IP Smoke sensor."""
@@ -1176,6 +1191,7 @@ DEVICETYPES = {
     "HM-Sec-SD-Generic": Smoke,
     "HM-Sec-SD-2": SmokeV2,
     "HM-Sec-SD-2-Generic": SmokeV2,
+    "HM-Sec-SD-2-Team": SmokeV2Team,
     "HmIP-SWSD": IPSmoke,
     "HM-Sen-MDIR-WM55": RemoteMotion,
     "HM-Sen-MDIR-SM": Motion,


### PR DESCRIPTION
This adds support for teams of HM-Sec-SD-2 devices using the SmokeV2Team class.

In the homematic integration I also had to add the following lines in the const.py to the HM_ATTRIBUTE_SUPPORT dict:

    "SENDERID": ["last_senderid", {}],
    "SENDERADDRESS": ["last_senderaddress", {}],
    "ERROR_ALARM_TEST": ["error_alarm_test", {0: "No", 1: "Yes"}],
    "ERROR_SMOKE_CHAMBER": ["error_smoke_chamber", {0: "No", 1: "Yes"}],

The sender* attrbutes show, which detector of the team has triggered the alarm. The ERROR* attributes show if an individual detector is in an error state.

I don't know if the is_smoke() is required as I did not find a caller but I copied it from the SmokeV2 class anyways.
