### PR TITLE
RSSI for HmIP-DRSI1

### DIFF
--- a/pyhomematic/devicetypes/actors.py
+++ b/pyhomematic/devicetypes/actors.py
@@ -572,7 +572,7 @@ class IPSwitch(GenericSwitch, HelperActionOnTime):
         super().__init__(device_description, proxy, resolveparamsets)
 
         channels = []
-        if "HMIP-PS" in self.TYPE.upper() or "HmIP-PCBS" in self.TYPE or "HmIP-DRSI1" in self.TYPE or "HmIP-FSI16" in self.TYPE:
+        if "HMIP-PS" in self.TYPE.upper() or "HmIP-PCBS" in self.TYPE or "HmIP-FSI16" in self.TYPE:
             channels = [1]
         elif "HmIP-MOD-OC8" in self.TYPE:
             channels = [1,2,3,4,5,6,7,8]
@@ -599,6 +599,26 @@ class IPSwitch(GenericSwitch, HelperActionOnTime):
             return [3]
 
 
+class IPSwitchRssiDevice(GenericSwitch, HelperActionOnTime, HelperRssiDevice):
+    """
+    Switch turning attached device on or off.
+    """
+    def __init__(self, device_description, proxy, resolveparamsets=False):
+        super().__init__(device_description, proxy, resolveparamsets)
+
+        channels = []
+        if "HmIP-DRSI1" in self.TYPE:
+            channels = [1]
+
+        if channels:
+            self.EVENTNODE.update({"PRESS_SHORT": channels,
+                                   "PRESS_LONG": channels})
+
+    @property
+    def ELEMENT(self):
+        return [3]        
+
+        
 class IPSwitchBattery(GenericSwitch, HelperActionOnTime, HelperLowBatIP):
     """
     Battery powered switch turning attached device on or off.
@@ -1179,7 +1199,7 @@ DEVICETYPES = {
     "HmIP-PCBS-BAT": IPSwitchBattery,
     "HmIP-PMFS": IPSwitch,
     "HmIP-MOD-OC8": IPSwitch,
-    "HmIP-DRSI1": IPSwitch,
+    "HmIP-DRSI1": IPSwitchRssiDevice,
     "HmIP-DRSI4": IPSwitch,
     "HmIP-BSL": IPKeySwitchLevel,
     "HmIP-USBSM": IPSwitchPowermeter,


### PR DESCRIPTION
Add IPSwitchRssiDevice and assign to HmIP-DRSI1. Further, e.g. HmIP-DRSI4, to switch to this class if tested.

Please point your pull request at the __devel__ branch. Also provide some information about the changes.

This pull request:
- fixes issue: [428](https://github.com/danielperna84/pyhomematic/issues/428)
- adds support for HomeMatic device: HmIP-DRSI1
  - New class: IPSwitchRssiDevice
  - Home Assistant [platform](https://github.com/home-assistant/home-assistant/blob/0da3e737651a150c17016f43b5f9144deff7ddd7/homeassistant/components/homematic/__init__.py#L65): DISCOVER_SWITCHES
- does the following: RssiDevice attribute for HmIP-DRSI1

If there is a cleaner way to do this, e.g. IPSwitchRssiDevice only adds HelperRssiDevice and IPSwitch and inherits then everything from IPSwitch without redefinition like I did it, please correct this accordingly.
