### PR TITLE
Add new HMIP Evo (HmIP-eTRV-E)

### DIFF
--- a/pyhomematic/devicetypes/thermostats.py
+++ b/pyhomematic/devicetypes/thermostats.py
@@ -470,6 +470,7 @@ DEVICETYPES = {
     "HmIP-eTRV-B1": IPThermostat,
     "HmIP-eTRV-C": IPThermostat,
     "HmIP-eTRV-C-2": IPThermostat,
+    "HmIP-eTRV-E": IPThermostat,
     "Thermostat AA": IPThermostat,
     "Thermostat AA GB": IPThermostat,
     "HmIP-STHD": IPThermostatWall2,


### PR DESCRIPTION
Please point your pull request at the __devel__ branch. Also provide some information about the changes.

This pull request:
- adds support for HomeMatic device: HmIP-eTRV-E
  - Home Assistant [platform](https://github.com/home-assistant/home-assistant/blob/0da3e737651a150c17016f43b5f9144deff7ddd7/homeassistant/components/homematic/__init__.py#L65): DISCOVER_CLIMATE
- does the following: Adds new HMIP Evo (HmIP-eTRV-E)
