### PR TITLE
Add device support for HmIP-WHS2

### DIFF
--- a/pyhomematic/devicetypes/actors.py
+++ b/pyhomematic/devicetypes/actors.py
@@ -897,7 +897,6 @@ class IPMultiIO(IPSwitch):
     def ELEMENT(self):
         return [2, 3, 4, 6, 7, 8]
 
-
 class ColorEffectLight(Dimmer):
     """
     Color light with dimmer function and color effects.
@@ -1064,6 +1063,20 @@ class IPMultiIOPCB(GenericSwitch, HelperRssiDevice, HelperRssiPeer):
     @property
     def ELEMENT(self):
         return self._doc
+
+class IPWHS2(GenericSwitch, HelperActionOnTime, HelperRssiDevice):
+    """
+    HmIP-WHS2 Central Heating and Hot Water actuator
+    """
+    def __init__(self, device_description, proxy, resolveparamsets=False):
+        super().__init__(device_description, proxy, resolveparamsets)
+
+        # Channels 1 and 5 show the state of physical output 1 and 2 respectively.
+        self.BINARYNODE.update({"STATE": [1, 5]})
+
+    @property
+    def ELEMENT(self):
+        return [2, 6]
 
 DEVICETYPES = {
     "HM-LC-Bl1-SM": Blind,
@@ -1235,4 +1248,5 @@ DEVICETYPES = {
     "HM-LC-DW-WM": ColdWarmDimmer,
     "HB-UNI-RGB-LED-CTRL": ColorEffectLight,
     "HmIP-MIO16-PCB": IPMultiIOPCB,
+    "HmIP-WHS2": IPWHS2,
 }


### PR DESCRIPTION
Please point your pull request at the __devel__ branch. Also provide some information about the changes.

This pull request:
- fixes issue: #330 #410 
- adds support for HomeMatic device: HmIP-WHS2
  - New class: IPWHS2
  - Home Assistant [platform](https://github.com/home-assistant/home-assistant/blob/0da3e737651a150c17016f43b5f9144deff7ddd7/homeassistant/components/homematic/__init__.py#L65): `DISCOVER_SWITCHES` and `DISCOVER_BINARY_SENSORS`
- does the following: Add device support for HmIP-WHS2. It has two binary sensors that show the state of the two physical outputs. These outputs have three controlling channels each ([2, 3, 4] and [6, 7, 8] that operate in an OR fashion (if any of them is "on", the output channel is "on"). This new class/device adds one of those channels per output (2 and 6), but the other two channels per output can still be controlled via the CCU, so including the binary sensors is important.

[For device parameters please see here.](https://gist.github.com/wokiener/9fb69d40cdadc8c4c35cf073a424950c)
