### PR TITLE
Add device support for HmIP-SFD

### DIFF
--- a/pyhomematic/devicetypes/sensors.py
+++ b/pyhomematic/devicetypes/sensors.py
@@ -209,6 +209,21 @@ class CO2SensorIP(SensorHmIPNoBattery):
                                 "ACTUAL_TEMPERATURE": [4]
                                 })
 
+class ParticulateMatterSensorIP(SensorHmIPNoBattery):
+    """Particulate matter sensor"""
+
+    def __init__(self, device_description, proxy, resolveparamsets=False):
+        super().__init__(device_description, proxy, resolveparamsets)
+        self.SENSORNODE.update({"ACTUAL_TEMPERATURE": [1],
+                                "HUMIDITY": [1],
+                                "MASS_CONCENTRATION_PM_1": [1],
+                                "MASS_CONCENTRATION_PM_2_5": [1],
+                                "MASS_CONCENTRATION_PM_10": [1],
+                                "MASS_CONCENTRATION_PM_1_24H_AVERAGE": [1],
+                                "MASS_CONCENTRATION_PM_2_5_24H_AVERAGE": [1],
+                                "MASS_CONCENTRATION_PM_10_24H_AVERAGE": [1]
+                                })
+
 class WaterSensor(SensorHm, HelperSensorState):
     """Watter detect sensor."""
 
@@ -1285,4 +1300,5 @@ DEVICETYPES = {
     "HmIP-STE2-PCB": TempModuleSTE2,
     "HmIP-SCTH230": CO2SensorIP,
     "HmIP-DLD": IPLockDLD,
+    "HmIP-SFD": ParticulateMatterSensorIP,
 }


### PR DESCRIPTION
This pull request:
- fixes issue: #438
- adds support for HomeMatic device: HmIP-SFD
  - New class: `ParticulateMatterSensorIP`
  - Home Assistant [platform](https://github.com/home-assistant/core/blob/05353f8e13ac7aeabbe7489c86c416c82d9a1d67/homeassistant/components/homematic/const.py#L43): `DISCOVER_SENSORS`

This new sensor also requires some additions to [`HM_UNIT_HA_CAST`](https://github.com/home-assistant/core/blob/05353f8e13ac7aeabbe7489c86c416c82d9a1d67/homeassistant/components/homematic/sensor.py#L48) and [`HM_DEVICE_CLASS_HA_CAST`](https://github.com/home-assistant/core/blob/05353f8e13ac7aeabbe7489c86c416c82d9a1d67/homeassistant/components/homematic/sensor.py#L81) in the Home Assistant integration. 