### PR TITLE
Add device support for "new" version of HmIP-SMI55

### DIFF
--- a/pyhomematic/devicetypes/sensors.py
+++ b/pyhomematic/devicetypes/sensors.py
@@ -1230,6 +1230,7 @@ DEVICETYPES = {
     "HM-Sec-MD": MotionV2,
     "HmIP-SMI": MotionIPContactSabotage,
     "HmIP-SMI55": IPRemoteMotionV2,
+    "HmIP-SMI55-2": IPRemoteMotionV2,
     "HmIP-SMO": MotionIP,
     "HmIP-SMO-A": MotionIP,
     "HmIP-SPI": PresenceIP,


### PR DESCRIPTION
This pull request:
- fixes issue: #445 
- adds support for HomeMatic device: HmIP-SMI55-2